### PR TITLE
Add pheonixrt wiki docs from Google Code

### DIFF
--- a/docs/wiki/DesignRtModel.md
+++ b/docs/wiki/DesignRtModel.md
@@ -1,0 +1,14 @@
+# Introduction #
+
+RtModel contains the data model for plans, structures, and images, as well as logic for persistence of the data.  It also contains algorithms for
+  * Optimization from a prescription
+  * Calculating Dose-volume histograms
+  * Calculating Dose (in the case that dose hasn't been imported)
+
+# Details #
+
+Attached is a [class diagram](https://lh4.googleusercontent.com/-KhcqEnnSe_o/U_KNJY_1b1I/AAAAAAAAlOg/q3OTA0TIuUI/w724-h762-no/phx.png) showing the main class relationships within the RtModel package.
+
+![https://lh4.googleusercontent.com/-KhcqEnnSe_o/U_KNJY_1b1I/AAAAAAAAlOg/q3OTA0TIuUI/w724-h762-no/phx.png](https://lh4.googleusercontent.com/-KhcqEnnSe_o/U_KNJY_1b1I/AAAAAAAAlOg/q3OTA0TIuUI/w724-h762-no/phx.png)
+
+_In the process of converting the optimizier to use the vnl optimization base.  Unfortunately the vnl conjugate gradient optimizer has no "hook" to be able to compute the dynamic covariance, so a completely separate DynamicCovarianceOptimizer is being used.  Also a DynamicCovarianceCostFunction implements those parts of the cost function that are specific to the DynamicCovariance technique._

--- a/docs/wiki/DicomBehavingBadly.md
+++ b/docs/wiki/DicomBehavingBadly.md
@@ -1,0 +1,7 @@
+# Introduction #
+
+After having spent a number of years dealing with very creative DICOM encodings, I thought maybe others might be amused by some of these.
+
+# Details #
+  * _NaN is Not A Number_ - so it shouldn't show up inside Decimal Strings, correct?  Maybe Varian's OBI and the Mirada planning system don't agree with this.  Of course, the fact that XiO and Mosaiq both pass the bad values through without flagging doesn't help anything...
+  * _Is an orthogonal grid supposed to be orthogonal_ - an old bug in the OBI used to produce (under some conditions) CBCTs with non-orthogonal volume grids.  This was specifically because the direction cosines were rotated (Varian rotates the direction cosines if the couch has been rotated), but the image positions were not adjusted to lie along the rotated Z-axis.

--- a/docs/wiki/DicomXmlSql.md
+++ b/docs/wiki/DicomXmlSql.md
@@ -1,0 +1,11 @@
+# Introduction #
+
+Add your content here.
+
+
+# Details #
+
+Add your content here.  Format your content with:
+  * Text in **bold** or _italic_
+  * Headings, paragraphs, and lists
+  * Automatic links to other wiki pages

--- a/docs/wiki/IHEBasicImageReview.md
+++ b/docs/wiki/IHEBasicImageReview.md
@@ -1,0 +1,8 @@
+# Introduction #
+The IHE Basic Image Review profile contains a lot of the things that were being attempted at Siemens Oncology years ago, as well as at Elekta more recently.  Standardization of UIs for image review is an idea whose time has come.
+
+
+# Details #
+  * [Basic Image Review](http://wiki.ihe.net/index.php?title=Basic_Image_Review)
+  * The main navigation is the use of interactive thumbnails, which is something we all know and love
+  * User interaction conventions for zoom/pan, window/level, and mouse wheel are all spelled out (including icons, which is a definite plus!)

--- a/docs/wiki/ImageGuidedDoseTracking.md
+++ b/docs/wiki/ImageGuidedDoseTracking.md
@@ -1,0 +1,11 @@
+# Introduction #
+
+Add your content here.
+
+
+# Details #
+
+Add your content here.  Format your content with:
+  * Text in **bold** or _italic_
+  * Headings, paragraphs, and lists
+  * Automatic links to other wiki pages

--- a/docs/wiki/ProjectHome.md
+++ b/docs/wiki/ProjectHome.md
@@ -1,0 +1,27 @@
+The main component of pheonixrt is an implementation of an optimization algorithm that can optimize various parameters for a given treatment, including
+  * the dose intensity map (analogous to inverse planning)
+  * a rigid or affine registration
+  * a treatment offset
+  * DVH curves
+
+In addition there is a component that can be used to analyze data imported from other systems.  This analysis can be used to determine:
+  * consistency with DICOM RT or IHE-RO
+  * verified algorithm implementations from other systems
+
+pheonixrt uses the [Insight Toolkit](http://itk.org/) for its basic image processing pipeline.
+
+[Why the New BSD License](https://code.google.com/p/pheonixrt/wiki/WhyOpenSource)
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/docs/wiki/ShiftVisualization.md
+++ b/docs/wiki/ShiftVisualization.md
@@ -1,0 +1,15 @@
+# Introduction #
+Interpretation of IGRT shift information is not the easiest thing in the world.  Elekta's Mosaiq, for one, has had a terrible time defining a coherent interpretation of shifts that is robust irrespective of online device conventions, regional settings, and general user entry errors.
+
+# Details #
+Maybe the problem is that we are expecting people to be more adept at spatial reasoning than the actually are.  Just copying values from a TrueBeam, and expecting no errors to be made is probably an unreasonable burden for most people, because they may not be able to tell easily if the values were copied wrong.  A simple substitution of a dot for a comma on an installation in another country could easily change the entered value by several orders of magnitude, especially if it were not noticed.
+
+But wouldn't a several order of magnitude shift be easily noticed?  For a pair of coregistered images, changing a shift of 0.1 cm to 100.0 cm would be easily noticed (and would inevitably create values that are outside the range of normal machine tolerance).  But what is the likelihood that a dot/comma confusion would cause a smaller error?
+
+I have produced a simulation of possible transpositions of dot/commas, and my results seem to indicate that, with proper bounds checking, the likelihood of a mis-entered value being silently accepted is limited to a fairly specific set of input ranges.  In particular, a value would need to be formatted as 9,999.999 or 99,999.999 in order to be susceptible to dot/comma transposition.  A number formatted 999.99 or smaller would be rejected: an incorrect thousand separator would cause the value to be larger than the maximum, and an incorrect decimal separator would be flagged as being below the allowed precision.
+
+At any rate, after entry has been made, typically a comparison is needed to another reference.  As we have learned with the TrueBeam offsets, this interpretation may involve comparing other coordinate systems or even other correction models.  An appropriate verification (see VerificationExpertSystem) would help to ensure that this is error-free.
+
+Finally, display of a visual indication of the shift would be great.  Here is a schematic I made to show one possible way of indicating 6 DoF shifts on a mannequin:
+
+![http://i.imgur.com/YA0ffcD.jpg](http://i.imgur.com/YA0ffcD.jpg)

--- a/docs/wiki/TechnicalDebt.md
+++ b/docs/wiki/TechnicalDebt.md
@@ -1,0 +1,11 @@
+# Introduction #
+It's called Technical Debt, but it's the same thing that the FDA's [software engineering lab](http://www.fda.gov/AboutFDA/CentersOffices/OfficeofMedicalProductsandTobacco/CDRH/CDRHOffices/ucm300540.htm) measures with its static analysis investigation.  The VerificationExpertSystem and related algorithmic verification techniques can establish the correct functioning of algorithms, but if the understanding of call paths is incomplete then it becomes difficult to ensure the correct operation of a complex piece of software under all relevent conditions.
+
+# Details #
+Static analysis and code coverage analysis can both be used to relate the results of a VerificationExpertSystem to the aggregate behavior of a software product.  Correct test coverage can then be determined by looking at whether all essential pathways through the software have been covered.
+
+But if a proprietary company has very old software, and no one really understands how large parts of the software operate (as is the case with Elekta's Mosaiq), then it becomes nearly impossible to make any kind of assurances that changes to the software design will be properly regression tested.  The result is numerous complaints from the field, and a management that is typically paralyzed by inaction because they clearly don't have a grasp on the complexity of the intrinsic risk of the device.  This result in things like the Elekta Hexapod Calculator fiasco...
+
+One might argue that open source software would not magically remove this problem, but it would allow a wider audience (including knowledgeable users) to become involved in the collective understanding of the code base.  So refactoring decisions could be made by the more knowledgeable community members, as opposed to know-nothing middle managers with no real grasp of the software.
+
+Maybe the best compromise between open source and proprietary approaches to design control of medical device software would be if the FDA required proprietary manufacturers to disclose the results of their static analysis. This would at least allow users to see statistically was going on inside the proprietary code base, and whether management was making progress in retiring technical debt.

--- a/docs/wiki/VerificationExpertSystem.md
+++ b/docs/wiki/VerificationExpertSystem.md
@@ -1,0 +1,29 @@
+# Introduction #
+
+Way back when I was working at Siemens I had the need to verify the behavior of an RT application (a CT simulator); this involved various computational geometry calculations, as well as a number of image processing operations.
+
+I had considered setting up some MATLAB programs that would implement algorithms parallel to what had been implemented (though presumably less efficient), but then I started considering the possibility that, when verifying an algorithm its not always necessary to compare it to another implementation.  In some cases (in fact in most cases) its possible to describe the 'correct' result of the algorithm in a declarative fashion, without actually specifying how the outputs are produced from the inputs.  In other words, what is described is a set of relationships that need to hold between the inputs and the outputs, but not necessarily the operations to be performed on the inputs in order to produce the outputs.
+
+At the time I had begun playing around with an open-source Prolog environment, [SWI-Prolog](http://www.swi-prolog.org/), that provided a fairly complete set of tools for writing and querying Prolog databases.
+
+
+# Details #
+
+A verification expert system is kinda like [executable requirements](http://agilemodeling.com/essays/agileRequirementsBestPractices.htm#ExecutableRequirements) on steroids.
+
+The verification predicates included checks on the accuracy and correctness of:
+  * Image geometry
+  * Contour placement
+  * Contour meshing and intersection
+  * 2D and 3D margin operations
+  * Threshold extraction
+  * Beam geometry
+
+More detailed explanation of the verification predicates can be found at this link:
+
+[Expert System for Geometric RTP Algorithms](http://pheonixrt.googlecode.com/files/Expert%20System%20for%20Geom%20RTP%20Algorithms.pdf)
+
+<a href='Hidden comment: 
+Generate the equation from the codecogs server:
+<img src="http://latex.codecogs.com/gif.latex?%5Cforall%20P_n%20%3A%20%5Cforall%20%5Cvec%7B%5Cmathbf%7Bv%7D%7D%20%5Cin%20P_n%20%3A%20%5Cvec%7B%5Cmathbf%7Bv%7D%7D%20%5Cin%20%7BM%7D%27" />
+'></a>

--- a/docs/wiki/WarpTPS.md
+++ b/docs/wiki/WarpTPS.md
@@ -1,0 +1,15 @@
+# Introduction #
+One of the problems to be addressed for adaptive treatment paradigms is the need to visualize and interact with deformable vector fields (DVF).  While a number of techniques exist for visualizing vector fields, such as heat maps and hedgehog plots, a simple technique is to allow interactive morphing to examine how the vector field is altering the target image to match the source.
+
+# Details #
+This is a very old MFC program that allows loading two different PNG images, and then provides a slider to morph back and forth between them.  The source code is self contained in the [WarpTPS](http://code.google.com/p/pheonixrt/source/browse/#svn%2Ftrunk%2FWarpTPS) source repository directory.
+
+Note that currently the two images that can be loaded through ` File > Open Images...` must be have the same width/height, and are both required to be in .BMP format.
+
+First is a video of Grumpy to Hedgy:
+
+<a href='http://www.youtube.com/watch?feature=player_embedded&v=ggDMs3GozSU' target='_blank'><img src='http://img.youtube.com/vi/ggDMs3GozSU/0.jpg' width='425' height=344 /></a>
+
+This video shows one MR slice being morphed on to another one:
+
+<a href='http://www.youtube.com/watch?feature=player_embedded&v=1w0Gk1YRcuI' target='_blank'><img src='http://img.youtube.com/vi/1w0Gk1YRcuI/0.jpg' width='425' height=344 /></a>

--- a/docs/wiki/WhatIfReOptimization.md
+++ b/docs/wiki/WhatIfReOptimization.md
@@ -1,0 +1,27 @@
+# Introduction #
+Assessing a large quantity of cone beam CTs has become a significant challenge in the current RT environment.  A method is needed to quickly filter images revealing information requiring in-depth analysis, as opposed to the majority of images that don't require in-depth analysis.
+
+If a method were available to quickly re-optimize a plan based on new information, this could provide an efficient filter based on the magnitude of improvement indicated by the re-optimization.
+
+# Details #
+
+"What-if" re-optimization asks the question: Given some additional information, how much better could the treatment be?  This may not be the same as re-optimizing as part of a replanning step, because the replanning may involve significantly more effort.  But if there is a means to quickly and easily perform a re-optimization based on additional data, then this could serve to aid the image assessment process.
+
+The workflow for reviewing a CBCT with what-if re-optimization:
+  1. An initial registration is imported as an SRO or done automatically
+  1. A second landmark-based TPS registration is based on a set of pre-defined landmarks specific to the anatomical site
+  1. Further manual adjustment of the landmarks fine-tune the fit
+  1. As the landmarks are adjusted, the pheonixrt algorithm dynamically updates the resulting re-optimization result
+  1. Decision:
+    * Stable DVHs >> landmark shifts do not significantly affect the treatment
+    * Significant variation in DVHs w.r.t. landmarks >> further investigation is warranted
+
+# The phoenixrt algorithm #
+
+The algorithm is a multi-resolution beamlet weight (influence matrix) optimization, based on matching of target DVH curve shapes using relative entropy.  More details can be found here: [US Patent 7369645](http://www.google.com/patents/US7369645).
+
+A video of the optimization for a simple "2.5D" case:
+
+<a href='http://www.youtube.com/watch?feature=player_embedded&v=eITwG8UhxOs' target='_blank'><img src='http://img.youtube.com/vi/eITwG8UhxOs/0.jpg' width='425' height=344 /></a>
+
+The "2.5D" case is a shallow volume of 5 slices with contours on the central slice, being optimized by a single row of beamlets on each beam.

--- a/docs/wiki/WhyOpenSource.md
+++ b/docs/wiki/WhyOpenSource.md
@@ -1,0 +1,36 @@
+# Introduction #
+
+Let's start with the typical product manager's job description:
+
+  * Ability to write vague, grammatically incorrect clinical requirements
+  * Ability to refuse to review detailed software requirements documents, or even try out new features, until after the release
+  * Ability to act surprised that the new software that one has never touched acts differently than one's expectations
+  * Ability to blame engineers for not being able to read minds
+
+Wouldn't an open process of submitting feature enhancement requests, voting on the most valuable ones, and then have an expandable pool of resources available to work on them would do just as well at getting software developed?
+
+# Details #
+
+Of course, one of the tricks is to ensure that an open source development process produces software of the same high quality as proprietary processes.  Because proprietary processes _always_ produce high quality software, correct?  Then again, you never really know for sure because you can't see the source code.  Does this make sense:  Acme Medical Software produces very high-quality code, and you know this because Acme Medical Software told you so.  Is this a scientific approach to software development?
+
+Being able to see the code may at least help you see how poorly written it is; but once the source code is out there in the public eye then (the belief is that) it will improve as more eyeballs look at it.  But for very critical software, just having a lot of eyeballs looking at it isn't enough.  It needs to be well-tested, and the tests need to have a low cost to run (as multiple iterations of the software are rapidly produced).
+
+Which suggests that automated testing is useful, but in the context of verifying software correctness this leads to a bit of a chicken-and-egg problem:  if the tests are comprehensive then their complexity is going to tend toward the larger size, and then how can you be sure that the test themselves are correct?
+
+This is where the verification 'expert system' comes in; using declarative logic its possible to write relatively concise descriptions of correct program behavior.  These descriptions, in this case written in Prolog, are then available to directly verify the open implementations.  They take a while to run, but these days CPU cycles are fairly plentiful.
+
+For the ITK point of view, see the chapter [in The Architecture of Open Source](http://www.aosabook.org/en/itk.html) book.
+
+# New BSD License #
+Copyright (c) 2007-2014, Derek G. Lane
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
## Summary

- Extracts the 12 markdown wiki pages from the orphan `pheonixrt/wiki` branch into `docs/wiki/`
- Preserves historical documentation from the original Google Code project migration
- Topics covered: RtModel design, DICOM handling, WarpTPS, shift visualization, optimization re-planning, verification expert system, technical debt, and the open source rationale

## Files

| Document | Topic |
|----------|-------|
| ProjectHome.md | Project overview and component summary |
| DesignRtModel.md | RtModel class architecture and optimizer design |
| WarpTPS.md | Thin-plate spline deformable registration |
| WhatIfReOptimization.md | Re-optimization workflow for adaptive planning |
| ShiftVisualization.md | Treatment shift visualization approach |
| VerificationExpertSystem.md | Expert system for treatment verification |
| TechnicalDebt.md | Known technical debt items |
| WhyOpenSource.md | Rationale for BSD license and open source |
| DicomBehavingBadly.md | DICOM conformance issues encountered |
| DicomXmlSql.md | DICOM/XML/SQL integration notes |
| IHEBasicImageReview.md | IHE-RO Basic Image Review profile |
| ImageGuidedDoseTracking.md | IGRT dose tracking concept |

## Test plan

- [x] All 12 files extracted and match original content on `pheonixrt/wiki` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)