### PR TITLE
WebView2 support + WebView2 convergence chart replacing the optimization graph

### DIFF
--- a/Brimstone/Brimstone.cpp
+++ b/Brimstone/Brimstone.cpp
@@ -49,6 +49,15 @@ CBrimstoneApp theApp;
 
 BOOL CBrimstoneApp::InitInstance()
 {
+	// Initialize OLE/COM (apartment-threaded) for the UI thread. Required by the
+	//	WebView2 control hosted in CBrimstoneView -- CreateCoreWebView2Environment
+	//	silently never completes without an STA-initialized COM thread.
+	if (!AfxOleInit())
+	{
+		AfxMessageBox(_T("OLE initialization failed."));
+		return FALSE;
+	}
+
 	AfxEnableControlContainer();
 
 	// Standard initialization

--- a/Brimstone/Brimstone.vcxproj
+++ b/Brimstone/Brimstone.vcxproj
@@ -307,6 +307,8 @@ copy "C:\Program Files (x86)\Intel\oneAPI\ipp\latest\bin\ippcore*.dll" $(OutDir)
     <ClCompile Include="MainFrm.cpp" />
     <ClCompile Include="OptThread.cpp" />
     <ClCompile Include="PlanarView.cpp" />
+    <ClCompile Include="WebView2Host.cpp" />
+    <ClCompile Include="OptGraphHtml.cpp" />
     <ClCompile Include="PlanSetupDlg.cpp" />
     <ClCompile Include="PrescriptionBar.cpp">
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</CompileAsManaged>
@@ -342,6 +344,8 @@ copy "C:\Program Files (x86)\Intel\oneAPI\ipp\latest\bin\ippcore*.dll" $(OutDir)
     <ClInclude Include="MainFrm.h" />
     <ClInclude Include="OptThread.h" />
     <ClInclude Include="PlanarView.h" />
+    <ClInclude Include="WebView2Host.h" />
+    <ClInclude Include="OptGraphHtml.h" />
     <ClInclude Include="PlanSetupDlg.h" />
     <ClInclude Include="PrescriptionBar.h">
       <FileType>CppControl</FileType>

--- a/Brimstone/BrimstoneView.cpp
+++ b/Brimstone/BrimstoneView.cpp
@@ -10,6 +10,7 @@
 
 #include "BrimstoneDoc.h"
 #include "BrimstoneView.h"
+#include "OptGraphHtml.h"
 
 #ifdef _DEBUG
 #define new DEBUG_NEW
@@ -234,6 +235,20 @@ int
 	m_pIterDS[3]->SetColor(RGB(255, 0, 255));
 	m_graphIterations.AddDataSeries(m_pIterDS[3]);
 
+	// WebView2 iteration/convergence chart. Placeholder geometry here; the real
+	//	rectangle (bottom-right quadrant) is set in OnSize. Phase 1: load a
+	//	self-contained test page to verify the WebView2 integration renders inside
+	//	the view. It sits over m_graphIterations, which still receives data so the
+	//	existing GDI flow is left untouched until the chart takes over.
+	m_webChart.Create(NULL, NULL, WS_VISIBLE | WS_CHILD | WS_CLIPSIBLINGS,
+		CRect(0, 400, 200, 600), this, /* nID */ 115);
+	m_webChart.NavigateToString(g_optGraphHtml);
+
+	// hide the legacy GDI iteration graph -- the WebView2 chart takes its place.
+	//	The data series remain attached to m_graphIterations so the existing
+	//	OnOptimizerThreadUpdate flow keeps working (it just paints into a hidden
+	//	window) until the chart is wired to receive the data directly.
+	m_graphIterations.ShowWindow(SW_HIDE);
 
 	return 0;
 }
@@ -307,7 +322,11 @@ void
 	m_graphDVH.MoveWindow(5 * cx / 8, 0, 3 * cx / 8, cy / 2);	
 
 	// reposition the iterations window
-	m_graphIterations.MoveWindow(5 * cx / 8, cy / 2, 3 * cx / 8, cy / 2);	
+	m_graphIterations.MoveWindow(5 * cx / 8, cy / 2, 3 * cx / 8, cy / 2);
+
+	// WebView2 chart occupies the same bottom-right quadrant, over the GDI graph
+	if (m_webChart.GetSafeHwnd() != NULL)
+		m_webChart.MoveWindow(5 * cx / 8, cy / 2, 3 * cx / 8, cy / 2);
 }
 
 
@@ -326,6 +345,9 @@ void
 		CMatrixNxM<> mEmpty;
 		for (int nL = 0; nL < dH::Structure::MAX_SCALES; nL++)
 			m_pIterDS[nL]->SetDataMatrix(mEmpty);
+
+		// clear the WebView2 convergence chart
+		m_webChart.ExecScript(_T("resetChart()"));
 
 		m_pOptThread->PostThreadMessage(WM_OPTIMIZER_START, 0, 0);
 		m_bOptimizerRun = true;
@@ -367,7 +389,13 @@ LRESULT
 
 		if (pOID->m_ofvalue > 0.0)
 		{
-			m_pIterDS[pOID->m_nLevel]->AddDataPoint(MakeVector<2>(m_nTotalIter, -log10(pOID->m_ofvalue)));
+			const double yVal = -log10(pOID->m_ofvalue);
+			m_pIterDS[pOID->m_nLevel]->AddDataPoint(MakeVector<2>(m_nTotalIter, yVal));
+
+			// feed the same point to the WebView2 convergence chart
+			CString strJs;
+			strJs.Format(_T("addPoint(%d,%d,%.6g)"), pOID->m_nLevel, m_nTotalIter, yVal);
+			m_webChart.ExecScript(strJs);
 		}
 
 		const int nUpdateEvery = 1;

--- a/Brimstone/BrimstoneView.h
+++ b/Brimstone/BrimstoneView.h
@@ -6,6 +6,7 @@
 #include <Graph.h>
 #include "PlanarView.h"	// Added by ClassView
 #include "OptThread.h"
+#include "WebView2Host.h"
 
 #if _MSC_VER > 1000
 #pragma once
@@ -43,6 +44,9 @@ public:
 	// graph to display iterations
 	CGraph m_graphIterations;
 	CDataSeries::Pointer m_dsIter;
+
+	// WebView2-hosted replacement for the iteration/convergence graph
+	CWebView2Host m_webChart;
 
 	// stores data series for iteration graph
 	CDataSeries::Pointer m_pIterDS[dH::Structure::MAX_SCALES];

--- a/Brimstone/OptGraphHtml.cpp
+++ b/Brimstone/OptGraphHtml.cpp
@@ -1,0 +1,96 @@
+// OptGraphHtml.cpp
+//
+// Copyright (C) 2nd Messenger Systems - U. S. Patent 7,369,645
+#include "stdafx.h"
+#include "OptGraphHtml.h"
+
+// A dependency-free canvas convergence chart: one colored line per pyramid
+// level (matching the legacy graph -- L0/finest=red, L1=green, L2=blue,
+// L3/coarsest=magenta), plotting -log10(F) against the global iteration index,
+// with auto-scaled axes, grid, title and legend. addPoint()/resetChart() are
+// installed on window for the host to call.
+const wchar_t* g_optGraphHtml = LR"HTML(<!doctype html>
+<html><head><meta charset="utf-8"><style>
+  html,body{margin:0;height:100%;background:#0b0b0f;overflow:hidden;
+    font:12px 'Segoe UI',Tahoma,sans-serif;color:#cccccc}
+  #wrap{position:absolute;left:0;top:0;right:0;bottom:0}
+  canvas{display:block}
+</style></head><body>
+<div id="wrap"><canvas id="cv"></canvas></div>
+<script>
+(function(){
+  var COLORS=['#ff4040','#40ff40','#4080ff','#ff40ff'];
+  var NAMES =['L0 (finest)','L1','L2','L3 (coarsest)'];
+  var PAD={l:54,r:12,t:24,b:28};
+  var series=[[],[],[],[]];
+  var dirty=true;
+  var cv=document.getElementById('cv'), ctx=cv.getContext('2d');
+  var W=0,H=0,DPR=window.devicePixelRatio||1;
+
+  function resize(){
+    var wrap=document.getElementById('wrap');
+    W=wrap.clientWidth; H=wrap.clientHeight;
+    cv.width=W*DPR; cv.height=H*DPR; cv.style.width=W+'px'; cv.style.height=H+'px';
+    ctx.setTransform(DPR,0,0,DPR,0,0); dirty=true;
+  }
+  window.addEventListener('resize',resize);
+
+  function bounds(){
+    var x0=Infinity,x1=-Infinity,y0=Infinity,y1=-Infinity,any=false,i,j,s,p;
+    for(i=0;i<4;i++){s=series[i];for(j=0;j<s.length;j++){any=true;p=s[j];
+      if(p.x<x0)x0=p.x; if(p.x>x1)x1=p.x; if(p.y<y0)y0=p.y; if(p.y>y1)y1=p.y;}}
+    if(!any){x0=0;x1=1;y0=0;y1=1;}
+    if(x1<=x0)x1=x0+1; if(y1<=y0)y1=y0+1;
+    var yp=(y1-y0)*0.08; y0-=yp; y1+=yp;
+    return {x0:x0,x1:x1,y0:y0,y1:y1};
+  }
+  function nice(range,ticks){
+    var raw=range/ticks, mag=Math.pow(10,Math.floor(Math.log(raw)/Math.LN10)), n=raw/mag;
+    return (n<1.5?1:n<3?2:n<7?5:10)*mag;
+  }
+  function draw(){
+    dirty=false; ctx.clearRect(0,0,W,H);
+    var b=bounds();
+    var pw=W-PAD.l-PAD.r, ph=H-PAD.t-PAD.b;
+    function px(x){return PAD.l+(x-b.x0)/(b.x1-b.x0)*pw;}
+    function py(y){return H-PAD.b-(y-b.y0)/(b.y1-b.y0)*ph;}
+    var y,x,X,Y,i,j,s;
+    ctx.lineWidth=1; ctx.strokeStyle='#23232b'; ctx.fillStyle='#888888';
+    ctx.textAlign='right'; ctx.textBaseline='middle';
+    var ys=nice(b.y1-b.y0,5);
+    for(y=Math.ceil(b.y0/ys)*ys; y<=b.y1; y+=ys){
+      Y=py(y); ctx.beginPath();ctx.moveTo(PAD.l,Y);ctx.lineTo(W-PAD.r,Y);ctx.stroke();
+      ctx.fillText(y.toFixed(2),PAD.l-6,Y);
+    }
+    ctx.textAlign='center'; ctx.textBaseline='top';
+    var xs=nice(b.x1-b.x0,6);
+    for(x=Math.ceil(b.x0/xs)*xs; x<=b.x1; x+=xs){
+      X=px(x); ctx.beginPath();ctx.moveTo(X,PAD.t);ctx.lineTo(X,H-PAD.b);ctx.stroke();
+      ctx.fillText(String(Math.round(x)),X,H-PAD.b+5);
+    }
+    ctx.lineWidth=1.5;
+    for(i=0;i<4;i++){s=series[i]; if(s.length<1)continue;
+      ctx.strokeStyle=COLORS[i]; ctx.beginPath();
+      for(j=0;j<s.length;j++){X=px(s[j].x);Y=py(s[j].y); if(j)ctx.lineTo(X,Y);else ctx.moveTo(X,Y);}
+      ctx.stroke();
+      X=px(s[s.length-1].x); Y=py(s[s.length-1].y);
+      ctx.fillStyle=COLORS[i]; ctx.beginPath(); ctx.arc(X,Y,2.5,0,6.2832); ctx.fill();
+    }
+    ctx.fillStyle='#dddddd'; ctx.textAlign='left'; ctx.textBaseline='top';
+    ctx.fillText('Convergence:  -log10(F)  vs  iteration',PAD.l,5);
+    ctx.textAlign='right';
+    for(i=0;i<4;i++){ if(series[i].length<1)continue;
+      ctx.fillStyle=COLORS[i]; ctx.fillText(NAMES[i],W-PAD.r,5+i*14);
+    }
+  }
+  function loop(){ if(dirty)draw(); window.requestAnimationFrame(loop); }
+
+  window.addPoint=function(level,x,y){
+    if(level>=0&&level<4&&isFinite(y)){ series[level].push({x:x,y:y}); dirty=true; }
+  };
+  window.resetChart=function(){ for(var i=0;i<4;i++)series[i].length=0; dirty=true; };
+
+  resize(); loop();
+})();
+</script></body></html>
+)HTML";

--- a/Brimstone/OptGraphHtml.h
+++ b/Brimstone/OptGraphHtml.h
@@ -1,0 +1,12 @@
+// OptGraphHtml.h
+//
+// The self-contained HTML/JS convergence chart rendered in the WebView2 host
+// that replaces the legacy GDI iteration graph. Exposes two JS entry points the
+// C++ side drives via ExecScript:
+//    addPoint(level, x, y)   -- append a point to a pyramid-level series
+//    resetChart()            -- clear all series (called when optimization starts)
+//
+// Copyright (C) 2nd Messenger Systems - U. S. Patent 7,369,645
+#pragma once
+
+extern const wchar_t* g_optGraphHtml;

--- a/Brimstone/WebView2Host.cpp
+++ b/Brimstone/WebView2Host.cpp
@@ -1,0 +1,174 @@
+// WebView2Host.cpp
+//
+// Copyright (C) 2nd Messenger Systems - U. S. Patent 7,369,645
+#include "stdafx.h"
+#include "WebView2Host.h"
+
+#include <wrl/event.h>
+
+// The WebView2 loader import lib. vcpkg's user-wide MSBuild integration puts
+// C:\vcpkg\installed\x64-windows\lib on the library search path and applocal-
+// deploys WebView2Loader.dll to the output dir, so no vcxproj/lib changes are
+// needed beyond this auto-link.
+#pragma comment(lib, "WebView2Loader.dll.lib")
+
+using namespace Microsoft::WRL;
+
+CWebView2Host::CWebView2Host()
+	: m_ready(false)
+	, m_navigated(false)
+	, m_navCompletedToken()
+{
+}
+
+CWebView2Host::~CWebView2Host()
+{
+	if (m_controller)
+		m_controller->Close();
+}
+
+BEGIN_MESSAGE_MAP(CWebView2Host, CWnd)
+	ON_WM_CREATE()
+	ON_WM_SIZE()
+END_MESSAGE_MAP()
+
+int CWebView2Host::OnCreate(LPCREATESTRUCT lpCreateStruct)
+{
+	if (CWnd::OnCreate(lpCreateStruct) == -1)
+		return -1;
+
+	InitEnvironment();
+	return 0;
+}
+
+void CWebView2Host::InitEnvironment()
+{
+	// WebView2 needs a writable user-data folder for the runtime; keep it out
+	//	of the exe directory (which may be read-only) by using the temp dir.
+	wchar_t tempPath[MAX_PATH] = { 0 };
+	GetTempPathW(MAX_PATH, tempPath);
+	std::wstring userDataFolder = std::wstring(tempPath) + L"BrimstoneWebView2";
+
+	const HWND hwndHost = m_hWnd;
+
+	CreateCoreWebView2EnvironmentWithOptions(
+		nullptr, userDataFolder.c_str(), nullptr,
+		Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(
+			[this, hwndHost](HRESULT result, ICoreWebView2Environment* env) -> HRESULT
+			{
+				if (FAILED(result) || env == nullptr)
+					return result;
+
+				env->CreateCoreWebView2Controller(
+					hwndHost,
+					Callback<ICoreWebView2CreateCoreWebView2ControllerCompletedHandler>(
+						[this](HRESULT result, ICoreWebView2Controller* controller) -> HRESULT
+						{
+							if (FAILED(result) || controller == nullptr)
+								return result;
+
+							OnControllerReady(controller);
+							return S_OK;
+						}).Get());
+				return S_OK;
+			}).Get());
+}
+
+void CWebView2Host::OnControllerReady(ICoreWebView2Controller* controller)
+{
+	m_controller = controller;
+	m_controller->get_CoreWebView2(&m_webview);
+	m_controller->put_IsVisible(TRUE);
+
+	// track navigation completion so queued scripts only run against a live page
+	if (m_webview)
+	{
+		m_webview->add_NavigationCompleted(
+			Callback<ICoreWebView2NavigationCompletedEventHandler>(
+				[this](ICoreWebView2* /*sender*/, ICoreWebView2NavigationCompletedEventArgs* /*args*/) -> HRESULT
+				{
+					m_navigated = true;
+					FlushScripts();
+					return S_OK;
+				}).Get(),
+			&m_navCompletedToken);
+	}
+
+	m_ready = true;
+	ResizeToClient();
+	FlushNavigate();
+}
+
+void CWebView2Host::ResizeToClient()
+{
+	if (!m_controller || m_hWnd == NULL)
+		return;
+
+	CRect rc;
+	GetClientRect(&rc);
+	RECT bounds = { 0, 0, rc.Width(), rc.Height() };
+	m_controller->put_Bounds(bounds);
+}
+
+void CWebView2Host::OnSize(UINT nType, int cx, int cy)
+{
+	CWnd::OnSize(nType, cx, cy);
+	ResizeToClient();
+}
+
+void CWebView2Host::Navigate(LPCWSTR url)
+{
+	if (m_ready && m_webview)
+		m_webview->Navigate(url);
+	else
+	{
+		m_pendingUrl = url;
+		m_pendingHtml.clear();
+	}
+}
+
+void CWebView2Host::NavigateToString(LPCWSTR html)
+{
+	if (m_ready && m_webview)
+		m_webview->NavigateToString(html);
+	else
+	{
+		m_pendingHtml = html;
+		m_pendingUrl.clear();
+	}
+}
+
+void CWebView2Host::ExecScript(LPCWSTR js)
+{
+	if (m_ready && m_navigated && m_webview)
+		m_webview->ExecuteScript(js, nullptr);
+	else
+		m_pendingScripts.push_back(js);
+}
+
+void CWebView2Host::FlushNavigate()
+{
+	if (!m_webview)
+		return;
+
+	if (!m_pendingHtml.empty())
+	{
+		m_webview->NavigateToString(m_pendingHtml.c_str());
+		m_pendingHtml.clear();
+	}
+	else if (!m_pendingUrl.empty())
+	{
+		m_webview->Navigate(m_pendingUrl.c_str());
+		m_pendingUrl.clear();
+	}
+}
+
+void CWebView2Host::FlushScripts()
+{
+	if (!m_webview)
+		return;
+
+	for (const std::wstring& s : m_pendingScripts)
+		m_webview->ExecuteScript(s.c_str(), nullptr);
+	m_pendingScripts.clear();
+}

--- a/Brimstone/WebView2Host.h
+++ b/Brimstone/WebView2Host.h
@@ -1,0 +1,59 @@
+// WebView2Host.h
+//
+// A CWnd that hosts a Microsoft Edge WebView2 control. WebView2 initialization
+// is asynchronous (COM completion callbacks pumped on the UI thread), so any
+// Navigate / NavigateToString / ExecScript request made before the control is
+// ready is queued and flushed once it is.
+//
+// Copyright (C) 2nd Messenger Systems - U. S. Patent 7,369,645
+#pragma once
+
+#include <wrl.h>
+#include <WebView2.h>
+
+#include <string>
+#include <vector>
+
+class CWebView2Host : public CWnd
+{
+public:
+	CWebView2Host();
+	virtual ~CWebView2Host();
+
+	// navigate to a URL (e.g. a file:/// path or virtual host) -- queued if not ready
+	void Navigate(LPCWSTR url);
+
+	// render an inline, self-contained HTML string -- queued if not ready
+	void NavigateToString(LPCWSTR html);
+
+	// run JavaScript in the current page -- queued until the page has loaded
+	void ExecScript(LPCWSTR js);
+
+	// true once the WebView2 controller is created and a page has finished loading
+	bool IsReady() const { return m_ready; }
+	bool IsNavigated() const { return m_navigated; }
+
+protected:
+	afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
+	afx_msg void OnSize(UINT nType, int cx, int cy);
+	DECLARE_MESSAGE_MAP()
+
+private:
+	void InitEnvironment();
+	void OnControllerReady(ICoreWebView2Controller* controller);
+	void ResizeToClient();
+	void FlushNavigate();
+	void FlushScripts();
+
+	Microsoft::WRL::ComPtr<ICoreWebView2Controller> m_controller;
+	Microsoft::WRL::ComPtr<ICoreWebView2> m_webview;
+	EventRegistrationToken m_navCompletedToken;
+
+	bool m_ready;		// controller + webview created
+	bool m_navigated;	// a page has finished loading (scripts can run)
+
+	// requests queued until ready / navigated
+	std::wstring m_pendingUrl;
+	std::wstring m_pendingHtml;
+	std::vector<std::wstring> m_pendingScripts;
+};


### PR DESCRIPTION
Adds Microsoft Edge **WebView2** hosting to the MFC Brimstone app and uses it to replace the legacy GDI optimization graph with a live HTML/JS convergence chart.

## What's in it

**1. WebView2 host control (`0f5e8bd`)**
- `CWebView2Host` (`WebView2Host.h/.cpp`) — a `CWnd` that embeds a WebView2 control: async COM bring-up (environment → controller → core webview), resizes to the client rect on `WM_SIZE`, and queues `Navigate`/`NavigateToString`/`ExecScript` requests made before it's ready (scripts also wait for `NavigationCompleted`).
- `CBrimstoneApp::InitInstance` now calls `AfxOleInit()` — WebView2 requires an STA-initialized COM thread, and environment creation silently never completes without it.

**2. Convergence chart replacing the graph (`5c97fb4`)**
- `OptGraphHtml.cpp` — a self-contained, dependency-free canvas chart: one line per pyramid level in the original colors (L0/finest red … L3/coarsest magenta), `-log10(F)` vs. iteration, with auto-scaled axes, grid, title, and legend. Exposes `addPoint(level,x,y)` and `resetChart()`.
- `CBrimstoneView` hosts it (`m_webChart`) in the same bottom-right rectangle. `OnOptimizerThreadUpdate` feeds each point via `ExecScript(addPoint(...))` at the exact seam that fed the old series; `OnOptimize` calls `resetChart()`.
- The legacy `m_graphIterations` is created-but-hidden so its data series stay attached and the existing flow is untouched — a minimal, reversible diff rather than ripping out the GDI graph.

## Verification
Verified end to end: a real optimization live-populates the chart (screenshot below in the thread). As a bonus it visually confirms the coarse levels (L2/L3) do essentially no work while L1 and L0 carry the convergence.

## Dependencies
Same classic-vcpkg style as ITK — building fresh requires `vcpkg install webview2:x64-windows` (headers land on the existing include path; the loader lib auto-links via the vcpkg `*.lib` wildcard and `WebView2Loader.dll` applocal-deploys) plus the Evergreen WebView2 Runtime (ships with Windows 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)