### PR TITLE
Convert DVH graph to WebView2 with interactive structure editor

### DIFF
--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -1,0 +1,47 @@
+# Branches
+
+Notes on the local/remote branches in this repository. `main` is the integration
+branch; feature and bugfix branches are merged via PR and then deleted. The
+branches below are **unmerged and stale** — they are kept only for reference and
+should not be assumed to contain wanted work.
+
+Last reviewed: 2026-07-17.
+
+## Active
+
+- **`main`** — the integration branch. All shipped work lands here via pull
+  request (recent examples: the optimizer crash fixes, the variational
+  free-energy / entropy regularizer, and the WebView2 convergence chart).
+
+## Unmerged, stale branches (~5 months old, do not merge as-is)
+
+These predate a large amount of subsequent work on `main`. None of them need a
+PR: their useful content is already in `main`, and their unique content was
+either not adopted or is now far too far behind to merge cleanly.
+
+- **`local-main-changes`** (tip `269175a`) — adds a `CVectorN` class /
+  `VectorOps` and XML-logging classes (`CXMLLogFile`, `CXMLElement`).
+  **Superseded**: both `RtModel/include/VectorN.h` and the `XMLLogging/`
+  project are already present in `main` (they arrived via other history). No
+  unique content. Local-only (no upstream).
+
+- **`reorganize-classic-libs`** (tip `cd2e9e9`, also on `origin`) — the same
+  CVectorN/XML-logging commits plus a repository reorganization that moves the
+  "classic" libraries into `lib_classic/` and introduces a `src/` layout.
+  **Not adopted**: `main` has no `lib_classic/` or `src/` structure; the reorg
+  was abandoned. The remaining commits are already in `main`.
+
+- **`modernize-build-deps`** (tip `1c178c0`) — "replace IPP with a C++
+  implementation, use vcpkg ITK 5.4". **Dangerously stale**: `main` already uses
+  vcpkg ITK 5.4, and this branch's diff against `main` is roughly
+  **+256 / −21,315 lines across 269 files** — merging it would *delete* large
+  amounts of current work (including the Python test suite and recently added
+  gradient tests). If the IPP removal is ever wanted, redo it fresh against
+  today's `main` rather than resurrecting this branch. Local-only (no upstream).
+
+### Recommendation
+
+Delete these branches (and the `origin/reorganize-classic-libs` remote) once
+their reference value has been captured here. Should any idea from them be
+worth pursuing (e.g. dropping the IPP dependency), start a new branch from
+current `main` instead of reviving these.

--- a/Brimstone/Brimstone.vcxproj
+++ b/Brimstone/Brimstone.vcxproj
@@ -309,6 +309,7 @@ copy "C:\Program Files (x86)\Intel\oneAPI\ipp\latest\bin\ippcore*.dll" $(OutDir)
     <ClCompile Include="PlanarView.cpp" />
     <ClCompile Include="WebView2Host.cpp" />
     <ClCompile Include="OptGraphHtml.cpp" />
+    <ClCompile Include="DvhViewHtml.cpp" />
     <ClCompile Include="PlanSetupDlg.cpp" />
     <ClCompile Include="PrescriptionBar.cpp">
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</CompileAsManaged>
@@ -346,6 +347,7 @@ copy "C:\Program Files (x86)\Intel\oneAPI\ipp\latest\bin\ippcore*.dll" $(OutDir)
     <ClInclude Include="PlanarView.h" />
     <ClInclude Include="WebView2Host.h" />
     <ClInclude Include="OptGraphHtml.h" />
+    <ClInclude Include="DvhViewHtml.h" />
     <ClInclude Include="PlanSetupDlg.h" />
     <ClInclude Include="PrescriptionBar.h">
       <FileType>CppControl</FileType>

--- a/Brimstone/BrimstoneView.cpp
+++ b/Brimstone/BrimstoneView.cpp
@@ -6,11 +6,14 @@
 #include <HistogramDataSeries.h>
 #ifdef USE_RTOPT
 #include <TargetDVHSeries.h>
+#include <KLDivTerm.h>
+#include <PlanPyramid.h>
 #endif
 
 #include "BrimstoneDoc.h"
 #include "BrimstoneView.h"
 #include "OptGraphHtml.h"
+#include "DvhViewHtml.h"
 
 #ifdef _DEBUG
 #define new DEBUG_NEW
@@ -146,6 +149,198 @@ void
 }
 
 /////////////////////////////////////////////////////////////////////////////
+// WebView2 DVH view: data feed (C++ -> page) and edit handling (page -> C++)
+
+static CString ColorToHex(COLORREF c)
+{
+	CString s;
+	s.Format(_T("#%02x%02x%02x"), GetRValue(c), GetGValue(c), GetBValue(c));
+	return s;
+}
+
+void CBrimstoneView::SendStructuresToDvh()
+{
+#ifdef USE_RTOPT
+	CBrimstoneDoc *pDoc = GetDocument();
+	if (pDoc == NULL || !pDoc->m_pSeries)
+		return;
+	dH::PlanOptimizer *pOpt = pDoc->m_pOptimizer.get();
+	dH::Prescription *pPresc0 = (pOpt != NULL) ? pOpt->GetPrescription(0) : NULL;
+
+	CString js = _T("setStructures([");
+	const int n = pDoc->m_pSeries->GetStructureCount();
+	for (int i = 0; i < n; i++)
+	{
+		dH::Structure *pStruct = pDoc->m_pSeries->GetStructureAt(i);
+		double mn = 0.0, mx = 0.0, wt = 0.0;
+		dH::VOITerm *pVOIT = (pPresc0 != NULL) ? pPresc0->GetStructureTerm(pStruct) : NULL;
+		if (pVOIT != NULL)
+		{
+			wt = pVOIT->GetWeight();
+			dH::KLDivTerm *pKL = dynamic_cast<dH::KLDivTerm*>(pVOIT);
+			if (pKL != NULL) { mn = pKL->GetMinDose() * 100.0; mx = pKL->GetMaxDose() * 100.0; }
+		}
+
+		CString name(pStruct->GetName().c_str());
+		name.Replace(_T("\\"), _T("\\\\"));
+		name.Replace(_T("\""), _T("\\\""));
+
+		CString item;
+		item.Format(_T("%s{\"id\":%d,\"name\":\"%s\",\"color\":\"%s\",\"type\":%d,\"min\":%.4g,\"max\":%.4g,\"weight\":%.4g,\"priority\":%d}"),
+			(i ? _T(",") : _T("")), i, (LPCTSTR)name, (LPCTSTR)ColorToHex(pStruct->GetColor()),
+			(int)pStruct->GetType(), mn, mx, wt, pStruct->GetPriority());
+		js += item;
+	}
+	js += _T("])");
+	m_webDVH.ExecScript(js);
+#endif
+}
+
+void CBrimstoneView::SendDvhCurvesToDvh()
+{
+#ifdef USE_RTOPT
+	CString js = _T("setDvh([");
+	const int cnt = m_graphDVH.GetDataSeriesCount();
+	bool first = true;
+	for (int i = 0; i < cnt; i++)
+	{
+		CDataSeries *pS = m_graphDVH.GetDataSeriesAt(i);
+		if (pS == NULL)
+			continue;
+		const bool bTarget = (dynamic_cast<CTargetDVHSeries*>(pS) != NULL);
+		const CMatrixNxM<>& m = pS->GetDataMatrix();
+		const int nPts = m.GetCols();
+
+		CString pts;
+		int emitted = 0;
+		for (int c = 0; c < nPts; c++)
+		{
+			const double x = m[c][0];	// 100 * dose
+			const double y = m[c][1];	// volume %
+			if (x < 0.0)
+				continue;				// the GDI graph clips X<0 too
+			CString p;
+			p.Format(_T("%s[%.3g,%.3g]"), (emitted ? _T(",") : _T("")), x, y);
+			pts += p;
+			emitted++;
+		}
+
+		CString item;
+		item.Format(_T("%s{\"id\":%d,\"color\":\"%s\",\"target\":%s,\"pts\":[%s]}"),
+			(first ? _T("") : _T(",")), i, (LPCTSTR)ColorToHex(pS->GetColor()),
+			(bTarget ? _T("true") : _T("false")), (LPCTSTR)pts);
+		js += item;
+		first = false;
+	}
+	js += _T("])");
+	m_webDVH.ExecScript(js);
+#endif
+}
+
+void CBrimstoneView::OnDvhMessage(const std::wstring & msg)
+{
+#ifdef USE_RTOPT
+	CBrimstoneDoc *pDoc = GetDocument();
+	if (pDoc == NULL || !pDoc->m_pSeries)
+		return;
+	dH::PlanOptimizer *pOpt = pDoc->m_pOptimizer.get();
+
+	// split "cmd|arg|arg..."
+	CString s(msg.c_str());
+	CStringArray tok;
+	int pos = 0;
+	for (CString t = s.Tokenize(_T("|"), pos); !t.IsEmpty(); t = s.Tokenize(_T("|"), pos))
+		tok.Add(t);
+	if (tok.GetSize() < 1)
+		return;
+	const CString cmd = tok[0];
+
+	dH::Series *pSeries = pDoc->m_pSeries;
+	const int nStructs = pSeries->GetStructureCount();
+
+	if (cmd == _T("weight") && tok.GetSize() >= 3 && pOpt != NULL)
+	{
+		const int id = _wtoi(tok[1]);
+		if (id >= 0 && id < nStructs)
+		{
+			dH::VOITerm *pV = pOpt->GetPrescription(0)->GetStructureTerm(pSeries->GetStructureAt(id));
+			if (pV != NULL)
+				pV->SetWeight(_wtof(tok[2]));
+		}
+	}
+	else if (cmd == _T("interval") && tok.GetSize() >= 4 && pOpt != NULL)
+	{
+		const int id = _wtoi(tok[1]);
+		const double mn = _wtof(tok[2]), mx = _wtof(tok[3]);
+		if (id >= 0 && id < nStructs && mn < mx)
+		{
+			dH::VOITerm *pV = pOpt->GetPrescription(0)->GetStructureTerm(pSeries->GetStructureAt(id));
+			dH::KLDivTerm *pK = dynamic_cast<dH::KLDivTerm*>(pV);
+			if (pK != NULL)
+				pK->SetInterval((REAL)(mn / 100.0), (REAL)(mx / 100.0), 1.0, TRUE);
+		}
+	}
+	else if (cmd == _T("color") && tok.GetSize() >= 3)
+	{
+		const int id = _wtoi(tok[1]);
+		const unsigned int rgb = wcstoul(tok[2], NULL, 16);
+		if (id >= 0 && id < nStructs)
+			pSeries->GetStructureAt(id)->SetColor(RGB((rgb >> 16) & 0xff, (rgb >> 8) & 0xff, rgb & 0xff));
+	}
+	else if (cmd == _T("type") && tok.GetSize() >= 3 && pOpt != NULL)
+	{
+		const int id = _wtoi(tok[1]);
+		const int newType = _wtoi(tok[2]);
+		if (id >= 0 && id < nStructs)
+		{
+			dH::Structure *pStruct = pSeries->GetStructureAt(id);
+			dH::Prescription *pP0 = pOpt->GetPrescription(0);
+			dH::VOITerm *pV = pP0->GetStructureTerm(pStruct);
+			pStruct->SetType((dH::Structure::StructType) newType);
+
+			if (newType == dH::Structure::eNONE)
+			{
+				if (pV != NULL)
+					for (int lvl = 0; lvl < dH::PlanPyramid::MAX_SCALES; lvl++)
+						pOpt->GetPrescription(lvl)->RemoveStructureTerm(pStruct);
+				RemoveHistogram(pStruct);
+			}
+			else if (pV == NULL)
+			{
+				// set weight + interval BEFORE AddStructTerm: it clones the term
+				// per pyramid level at call time, so later edits wouldn't propagate
+				dH::KLDivTerm::Pointer pKL = dH::KLDivTerm::New();
+				pKL->SetVOI(pStruct);
+				pKL->SetWeight((REAL)2.5);
+				const double d1 = (newType == dH::Structure::eTARGET) ? 0.60 : 0.0;
+				const double d2 = (newType == dH::Structure::eTARGET) ? 0.70 : 0.30;
+				pKL->SetInterval((REAL)d1, (REAL)d2, 1.0, TRUE);
+				AddStructTerm(pKL);		// clones across levels + adds the target curve
+				AddHistogram(pStruct);
+			}
+			pP0->SetElementInclude();
+		}
+	}
+	else if (cmd == _T("order") && tok.GetSize() >= 2)
+	{
+		int p2 = 0, prio = 0;
+		for (CString idt = tok[1].Tokenize(_T(","), p2); !idt.IsEmpty(); idt = tok[1].Tokenize(_T(","), p2))
+		{
+			const int id = _wtoi(idt);
+			if (id >= 0 && id < nStructs)
+				pSeries->GetStructureAt(id)->SetPriority(prio);
+			prio++;
+		}
+	}
+
+	// reflect the change back to the page and repaint the image view (colors/regions)
+	SendStructuresToDvh();
+	SendDvhCurvesToDvh();
+	RedrawWindow(NULL, NULL, RDW_INVALIDATE);
+#endif
+}
+
+/////////////////////////////////////////////////////////////////////////////
 // CBrimstoneView drawing
 
 /////////////////////////////////////////////////////////////////////////////
@@ -217,11 +412,21 @@ int
 	m_graphDVH.Create(NULL, NULL, WS_BORDER | WS_VISIBLE | WS_CHILD | WS_CLIPSIBLINGS, 
 		CRect(0, 200, 200, 400), this, /* nID */ 113);
 
-	m_graphDVH.SetLegendLUT(m_arrColormap, 
+	m_graphDVH.SetLegendLUT(m_arrColormap,
 		m_wndPlanarView.m_window[1], m_wndPlanarView.m_level[1]);
 
+	// WebView2 DVH view (chart + Target/OAR/None structure editor) in the same
+	//	top-right quadrant. Placeholder geometry; real rect set in OnSize. The
+	//	legacy GDI m_graphDVH is hidden -- its CHistogramDataSeries stay attached
+	//	so GetDataMatrix() still yields the DVH curves we forward to the page.
+	m_webDVH.Create(NULL, NULL, WS_VISIBLE | WS_CHILD | WS_CLIPSIBLINGS,
+		CRect(0, 200, 200, 400), this, /* nID */ 116);
+	m_webDVH.SetMessageHandler([this](const std::wstring& msg) { OnDvhMessage(msg); });
+	m_webDVH.NavigateToString(g_dvhViewHtml);
+	m_graphDVH.ShowWindow(SW_HIDE);
+
 	// create the graph window
-	m_graphIterations.Create(NULL, NULL, WS_BORDER | WS_VISIBLE | WS_CHILD | WS_CLIPSIBLINGS, 
+	m_graphIterations.Create(NULL, NULL, WS_BORDER | WS_VISIBLE | WS_CHILD | WS_CLIPSIBLINGS,
 		CRect(0, 200, 200, 400), this, /* nID */ 114);
 
 	for (int nD = 0; nD < dH::Structure::MAX_SCALES; nD++)
@@ -308,10 +513,14 @@ void
 	}
 
 	m_graphDVH.Invalidate(TRUE);
+
+	// seed the WebView2 DVH view with the current structures + curves
+	SendStructuresToDvh();
+	SendDvhCurvesToDvh();
 }
 
 /////////////////////////////////////////////////////////////////////////////
-void 
+void
 	CBrimstoneView::OnSize(UINT nType, int cx, int cy) 
 {
 	CView::OnSize(nType, cx, cy);
@@ -319,7 +528,11 @@ void
 	m_wndPlanarView.MoveWindow(0, 0, 5 * cx / 8, cy);
 
 	// reposition the graph window
-	m_graphDVH.MoveWindow(5 * cx / 8, 0, 3 * cx / 8, cy / 2);	
+	m_graphDVH.MoveWindow(5 * cx / 8, 0, 3 * cx / 8, cy / 2);
+
+	// WebView2 DVH view occupies the same top-right quadrant, over the GDI graph
+	if (m_webDVH.GetSafeHwnd() != NULL)
+		m_webDVH.MoveWindow(5 * cx / 8, 0, 3 * cx / 8, cy / 2);
 
 	// reposition the iterations window
 	m_graphIterations.MoveWindow(5 * cx / 8, cy / 2, 3 * cx / 8, cy / 2);
@@ -402,6 +615,7 @@ LRESULT
 		if (m_nTotalIter % nUpdateEvery == 0)
 		{
 			GetDocument()->m_pOptimizer->SetStateVectorToPlan(pOID->m_vParam);
+			SendDvhCurvesToDvh();
 		}
 		m_nTotalIter++;
 
@@ -421,6 +635,7 @@ LRESULT
 	if (pOID != NULL)
 	{
 		GetDocument()->m_pOptimizer->SetStateVectorToPlan(pOID->m_vParam);
+		SendDvhCurvesToDvh();
 		RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW);
 	}
 

--- a/Brimstone/BrimstoneView.h
+++ b/Brimstone/BrimstoneView.h
@@ -48,6 +48,9 @@ public:
 	// WebView2-hosted replacement for the iteration/convergence graph
 	CWebView2Host m_webChart;
 
+	// WebView2-hosted DVH view: DVH chart + the Target/OAR/None structure editor
+	CWebView2Host m_webDVH;
+
 	// stores data series for iteration graph
 	CDataSeries::Pointer m_pIterDS[dH::Structure::MAX_SCALES];
 
@@ -57,6 +60,12 @@ public:
 
 	// add new structure term
 	void AddStructTerm(dH::VOITerm * pVOIT);
+
+	// WebView2 DVH view: push structure list + DVH curves to the page, and
+	//	handle edits (type/interval/weight/color/order) posted back from it
+	void SendStructuresToDvh();
+	void SendDvhCurvesToDvh();
+	void OnDvhMessage(const std::wstring & msg);
 
 // Operations
 public:

--- a/Brimstone/DvhViewHtml.cpp
+++ b/Brimstone/DvhViewHtml.cpp
@@ -1,0 +1,168 @@
+// DvhViewHtml.cpp
+//
+// Copyright (C) 2nd Messenger Systems - U. S. Patent 7,369,645
+#include "stdafx.h"
+#include "DvhViewHtml.h"
+
+const wchar_t* g_dvhViewHtml = LR"HTML(<!doctype html>
+<html><head><meta charset="utf-8"><style>
+  :root{--bg:#0b0b0f;--panel:#15151c;--line:#2a2a34;--txt:#cfcfd6;--dim:#8a8a95}
+  html,body{margin:0;height:100%;background:var(--bg);color:var(--txt);
+    font:12px 'Segoe UI',Tahoma,sans-serif;overflow:hidden}
+  #root{position:absolute;inset:0;display:flex;flex-direction:column}
+  #chartWrap{flex:1 1 55%;position:relative;min-height:80px}
+  canvas{display:block}
+  #lists{flex:1 1 45%;display:flex;gap:6px;padding:6px;box-sizing:border-box;min-height:120px}
+  .list{flex:1 1 0;background:var(--panel);border:1px solid var(--line);border-radius:4px;
+    display:flex;flex-direction:column;min-width:0}
+  .list h3{margin:0;padding:4px 8px;font-size:11px;font-weight:600;letter-spacing:.04em;
+    color:var(--dim);border-bottom:1px solid var(--line);text-transform:uppercase}
+  .rows{flex:1 1 0;overflow-y:auto;overflow-x:hidden}
+  .cols{display:flex;padding:2px 6px;font-size:10px;color:var(--dim);gap:4px}
+  .cols span{flex:1 1 0;min-width:0}
+  .cName{flex:2 1 0 !important}
+  .row{display:flex;align-items:center;gap:4px;padding:3px 6px;cursor:grab;
+    border-bottom:1px solid #1e1e26}
+  .row:hover{background:#1c1c24}
+  .row.drag{opacity:.4}
+  .row .sw{width:12px;height:12px;border-radius:2px;flex:0 0 auto;cursor:pointer;border:1px solid #000}
+  .row .nm{flex:2 1 0;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .row input{flex:1 1 0;min-width:0;width:100%;box-sizing:border-box;background:#0e0e14;
+    color:var(--txt);border:1px solid #26262f;border-radius:2px;font:11px monospace;padding:1px 3px}
+  .row input.w{color:#ffd479}
+  .list.over{outline:1px dashed #4080ff;outline-offset:-2px}
+  .hidecol{display:none}
+</style></head><body>
+<div id="root">
+  <div id="chartWrap"><canvas id="cv"></canvas></div>
+  <div id="lists">
+    <div class="list" data-type="1"><h3>Target</h3>
+      <div class="cols"><span class="cName">Name</span><span>Min</span><span>Max</span><span>Weight</span></div>
+      <div class="rows"></div></div>
+    <div class="list" data-type="2"><h3>OAR</h3>
+      <div class="cols"><span class="cName">Name</span><span>Min</span><span>Max</span><span>Weight</span></div>
+      <div class="rows"></div></div>
+    <div class="list" data-type="0"><h3>None</h3>
+      <div class="cols"><span class="cName">Name</span><span>Min</span><span>Max</span><span>Weight</span></div>
+      <div class="rows"></div></div>
+  </div>
+</div>
+)HTML" LR"HTML(
+<script>
+(function(){
+  function post(s){ if(window.chrome&&window.chrome.webview) window.chrome.webview.postMessage(s); }
+
+  // ---------- structure editor ----------
+  var structs={};       // id -> {id,name,color,type,min,max,weight,priority}
+  var dragId=null;
+
+  function fmt(v){ return (v==null||isNaN(v))?'':(+v).toFixed(2); }
+
+  function makeRow(s){
+    var row=document.createElement('div'); row.className='row'; row.draggable=true; row.dataset.id=s.id;
+    var sw=document.createElement('div'); sw.className='sw'; sw.style.background=s.color;
+    sw.title='color'; sw.onclick=function(e){e.stopPropagation(); pickColor(s.id, s.color);};
+    var nm=document.createElement('div'); nm.className='nm'; nm.textContent=s.name; nm.title=s.name;
+    var mn=document.createElement('input'); mn.value=fmt(s.min); mn.title='min dose';
+    var mx=document.createElement('input'); mx.value=fmt(s.max); mx.title='max dose';
+    var wt=document.createElement('input'); wt.className='w'; wt.value=fmt(s.weight); wt.title='weight';
+    mn.onchange=function(){ commitInterval(s.id, mn.value, mx.value); };
+    mx.onchange=function(){ commitInterval(s.id, mn.value, mx.value); };
+    wt.onchange=function(){ post('weight|'+s.id+'|'+(parseFloat(wt.value)||0)); };
+    // None list has no numeric fields
+    if(s.type===0){ mn.classList.add('hidecol'); mx.classList.add('hidecol'); wt.classList.add('hidecol'); }
+    row.appendChild(sw); row.appendChild(nm); row.appendChild(mn); row.appendChild(mx); row.appendChild(wt);
+    row.addEventListener('dragstart',function(e){ dragId=s.id; row.classList.add('drag'); e.dataTransfer.effectAllowed='move'; });
+    row.addEventListener('dragend',function(){ dragId=null; row.classList.add; row.classList.remove('drag'); });
+    return row;
+  }
+
+  function commitInterval(id,mn,mx){
+    var a=parseFloat(mn), b=parseFloat(mx);
+    if(isFinite(a)&&isFinite(b)) post('interval|'+id+'|'+a+'|'+b);
+  }
+  function pickColor(id,cur){
+    var inp=document.createElement('input'); inp.type='color'; inp.value=cur||'#808080';
+    inp.style.position='fixed'; inp.style.left='-100px'; document.body.appendChild(inp);
+    inp.addEventListener('input',function(){ post('color|'+id+'|'+inp.value.replace('#','')); });
+    inp.addEventListener('change',function(){ document.body.removeChild(inp); });
+    inp.click();
+  }
+
+  function rebuild(){
+    document.querySelectorAll('.list').forEach(function(list){
+      var t=+list.dataset.type, rows=list.querySelector('.rows'); rows.innerHTML='';
+      Object.values(structs).filter(function(s){return s.type===t;})
+        .sort(function(a,b){return a.priority-b.priority;})
+        .forEach(function(s){ rows.appendChild(makeRow(s)); });
+    });
+  }
+
+  // drag & drop between/within lists
+  function insertBefore(rows,y){
+    var els=[].slice.call(rows.querySelectorAll('.row:not(.drag)'));
+    for(var i=0;i<els.length;i++){ var r=els[i].getBoundingClientRect();
+      if(y < r.top + r.height/2) return els[i]; }
+    return null;
+  }
+  document.querySelectorAll('.list').forEach(function(list){
+    var rows=list.querySelector('.rows');
+    list.addEventListener('dragover',function(e){ e.preventDefault(); list.classList.add('over');
+      var after=insertBefore(rows,e.clientY); var drag=document.querySelector('.row.drag');
+      if(drag){ if(after) rows.insertBefore(drag,after); else rows.appendChild(drag); } });
+    list.addEventListener('dragleave',function(){ list.classList.remove('over'); });
+    list.addEventListener('drop',function(e){ e.preventDefault(); list.classList.remove('over');
+      if(dragId==null) return;
+      var newType=+list.dataset.type;
+      if(structs[dragId] && structs[dragId].type!==newType){ post('type|'+dragId+'|'+newType); }
+      // full display order across all lists -> priorities
+      var order=[];
+      document.querySelectorAll('.list .rows .row').forEach(function(r){ order.push(r.dataset.id); });
+      post('order|'+order.join(','));
+    });
+  });
+
+  window.setStructures=function(arr){
+    structs={}; (arr||[]).forEach(function(s){ structs[s.id]=s; }); rebuild();
+    draw();
+  };
+
+  // ---------- DVH chart ----------
+  var curves=[];  // {id,color,target,pts:[[dose,vol],...]}
+  var cv=document.getElementById('cv'), ctx=cv.getContext('2d');
+  var W=0,H=0,DPR=window.devicePixelRatio||1;
+  var PAD={l:40,r:10,t:10,b:22};
+  function resize(){ var w=document.getElementById('chartWrap');
+    W=w.clientWidth; H=w.clientHeight; cv.width=W*DPR; cv.height=H*DPR;
+    cv.style.width=W+'px'; cv.style.height=H+'px'; ctx.setTransform(DPR,0,0,DPR,0,0); draw(); }
+  window.addEventListener('resize',resize);
+
+  function draw(){
+    ctx.clearRect(0,0,W,H);
+    var xmax=1; for(var i=0;i<curves.length;i++){ var p=curves[i].pts; for(var j=0;j<p.length;j++) if(p[j][0]>xmax) xmax=p[j][0]; }
+    xmax=Math.ceil(xmax/10)*10 || 100;
+    var pw=W-PAD.l-PAD.r, ph=H-PAD.t-PAD.b;
+    function px(x){return PAD.l+x/xmax*pw;}
+    function py(v){return H-PAD.b-v/100*ph;}
+    ctx.strokeStyle='#23232b'; ctx.fillStyle='#888'; ctx.lineWidth=1;
+    ctx.textAlign='right'; ctx.textBaseline='middle';
+    for(var v=0; v<=100; v+=25){ var Y=py(v); ctx.beginPath();ctx.moveTo(PAD.l,Y);ctx.lineTo(W-PAD.r,Y);ctx.stroke(); ctx.fillText(v,PAD.l-4,Y); }
+    ctx.textAlign='center'; ctx.textBaseline='top';
+    var xs=Math.max(10,Math.round(xmax/5/10)*10);
+    for(var x=0;x<=xmax;x+=xs){ var X=px(x); ctx.beginPath();ctx.moveTo(X,PAD.t);ctx.lineTo(X,H-PAD.b);ctx.stroke(); ctx.fillText(x,X,H-PAD.b+4); }
+    for(var i=0;i<curves.length;i++){ var c=curves[i], p=c.pts; if(!p||p.length<1) continue;
+      ctx.strokeStyle=c.color; ctx.lineWidth=c.target?1:1.7; ctx.setLineDash(c.target?[4,3]:[]);
+      ctx.beginPath();
+      for(var j=0;j<p.length;j++){ var X=px(p[j][0]),Y=py(p[j][1]); if(j)ctx.lineTo(X,Y);else ctx.moveTo(X,Y); }
+      ctx.stroke();
+    }
+    ctx.setLineDash([]);
+    ctx.fillStyle='#bbb'; ctx.textAlign='left'; ctx.textBaseline='top';
+    ctx.fillText('DVH:  volume %  vs  dose',PAD.l,PAD.t);
+  }
+  window.setDvh=function(arr){ curves=arr||[]; draw(); };
+
+  resize();
+})();
+</script></body></html>
+)HTML";

--- a/Brimstone/DvhViewHtml.h
+++ b/Brimstone/DvhViewHtml.h
@@ -1,0 +1,22 @@
+// DvhViewHtml.h
+//
+// The self-contained HTML/JS page rendered in the DVH WebView2 host. It shows a
+// dose-volume-histogram chart plus an interactive structure/prescription editor:
+// three lists (Target / OAR / None), each a grid of Name/Color/Min/Max/Weight,
+// with drag-to-reorder (priority) and drag-between-lists (type).
+//
+// C++ -> page (via ExecScript):
+//    setStructures([{id,name,color,type,min,max,weight,priority}, ...])
+//    setDvh([{id,color,target,pts:[[dose,vol],...]}, ...])
+//
+// page -> C++ (via window.chrome.webview.postMessage, pipe-delimited strings):
+//    "type|<id>|<0|1|2>"          structure moved to None/Target/OAR
+//    "weight|<id>|<w>"            weight edited
+//    "interval|<id>|<min>|<max>"  min/max dose edited
+//    "color|<id>|<rrggbb>"        color edited
+//    "order|<id0>,<id1>,..."      full display order -> priorities
+//
+// Copyright (C) 2nd Messenger Systems - U. S. Patent 7,369,645
+#pragma once
+
+extern const wchar_t* g_dvhViewHtml;

--- a/Brimstone/WebView2Host.cpp
+++ b/Brimstone/WebView2Host.cpp
@@ -18,6 +18,7 @@ CWebView2Host::CWebView2Host()
 	: m_ready(false)
 	, m_navigated(false)
 	, m_navCompletedToken()
+	, m_webMessageToken()
 {
 }
 
@@ -80,7 +81,7 @@ void CWebView2Host::OnControllerReady(ICoreWebView2Controller* controller)
 	m_controller->get_CoreWebView2(&m_webview);
 	m_controller->put_IsVisible(TRUE);
 
-	// track navigation completion so queued scripts only run against a live page
+	// track navigation completion so queued scripts/messages only reach a live page
 	if (m_webview)
 	{
 		m_webview->add_NavigationCompleted(
@@ -89,9 +90,36 @@ void CWebView2Host::OnControllerReady(ICoreWebView2Controller* controller)
 				{
 					m_navigated = true;
 					FlushScripts();
+					FlushPosts();
 					return S_OK;
 				}).Get(),
 			&m_navCompletedToken);
+
+		// page -> host messages (window.chrome.webview.postMessage). Fired on the
+		//	UI thread; forwarded to the registered handler as a JSON string.
+		m_webview->add_WebMessageReceived(
+			Callback<ICoreWebView2WebMessageReceivedEventHandler>(
+				[this](ICoreWebView2* /*sender*/, ICoreWebView2WebMessageReceivedEventArgs* args) -> HRESULT
+				{
+					if (m_onMessage && args)
+					{
+						// the page posts plain strings (postMessage("cmd|a|b"));
+						//	fall back to the JSON form for non-string messages.
+						LPWSTR msg = nullptr;
+						if (SUCCEEDED(args->TryGetWebMessageAsString(&msg)) && msg)
+						{
+							m_onMessage(std::wstring(msg));
+							CoTaskMemFree(msg);
+						}
+						else if (SUCCEEDED(args->get_WebMessageAsJson(&msg)) && msg)
+						{
+							m_onMessage(std::wstring(msg));
+							CoTaskMemFree(msg);
+						}
+					}
+					return S_OK;
+				}).Get(),
+			&m_webMessageToken);
 	}
 
 	m_ready = true;
@@ -146,6 +174,14 @@ void CWebView2Host::ExecScript(LPCWSTR js)
 		m_pendingScripts.push_back(js);
 }
 
+void CWebView2Host::PostJson(LPCWSTR json)
+{
+	if (m_ready && m_navigated && m_webview)
+		m_webview->PostWebMessageAsJson(json);
+	else
+		m_pendingPosts.push_back(json);
+}
+
 void CWebView2Host::FlushNavigate()
 {
 	if (!m_webview)
@@ -171,4 +207,14 @@ void CWebView2Host::FlushScripts()
 	for (const std::wstring& s : m_pendingScripts)
 		m_webview->ExecuteScript(s.c_str(), nullptr);
 	m_pendingScripts.clear();
+}
+
+void CWebView2Host::FlushPosts()
+{
+	if (!m_webview)
+		return;
+
+	for (const std::wstring& s : m_pendingPosts)
+		m_webview->PostWebMessageAsJson(s.c_str());
+	m_pendingPosts.clear();
 }

--- a/Brimstone/WebView2Host.h
+++ b/Brimstone/WebView2Host.h
@@ -11,6 +11,7 @@
 #include <wrl.h>
 #include <WebView2.h>
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -29,6 +30,18 @@ public:
 	// run JavaScript in the current page -- queued until the page has loaded
 	void ExecScript(LPCWSTR js);
 
+	// post a structured message to the page (window.chrome.webview 'message'
+	//	event); json must be a valid JSON value. Queued until ready.
+	void PostJson(LPCWSTR json);
+
+	// register a handler for messages the page sends back via
+	//	window.chrome.webview.postMessage(...). Invoked on the UI thread with the
+	//	message serialized as a JSON string.
+	void SetMessageHandler(std::function<void(const std::wstring&)> handler)
+	{
+		m_onMessage = std::move(handler);
+	}
+
 	// true once the WebView2 controller is created and a page has finished loading
 	bool IsReady() const { return m_ready; }
 	bool IsNavigated() const { return m_navigated; }
@@ -44,16 +57,22 @@ private:
 	void ResizeToClient();
 	void FlushNavigate();
 	void FlushScripts();
+	void FlushPosts();
 
 	Microsoft::WRL::ComPtr<ICoreWebView2Controller> m_controller;
 	Microsoft::WRL::ComPtr<ICoreWebView2> m_webview;
 	EventRegistrationToken m_navCompletedToken;
+	EventRegistrationToken m_webMessageToken;
 
 	bool m_ready;		// controller + webview created
 	bool m_navigated;	// a page has finished loading (scripts can run)
+
+	// message handler for page -> host messages
+	std::function<void(const std::wstring&)> m_onMessage;
 
 	// requests queued until ready / navigated
 	std::wstring m_pendingUrl;
 	std::wstring m_pendingHtml;
 	std::vector<std::wstring> m_pendingScripts;
+	std::vector<std::wstring> m_pendingPosts;
 };


### PR DESCRIPTION
## Summary
Replaces the legacy GDI DVH graph with a WebView2-hosted page: a DVH chart plus an interactive **Target / OAR / None** structure editor. Each list is a grid of **Name / Color / Min / Max / Weight**, with drag-to-reorder (priority) and drag-between-lists (type change). Priority is derived from list order.

## What's included
- **`DvhViewHtml.h/.cpp`** — self-contained HTML/JS page. Canvas DVH chart on top; three drag-orderable grids below. The wide raw-string literal is split in two to stay under MSVC's ~8189 wide-char limit (C2026).
- **`CWebView2Host`** — adds the JS→C++ message path (`SetMessageHandler` / `add_WebMessageReceived` / `PostJson` / `FlushPosts`) alongside the existing C++→JS `ExecScript` flow.
- **`CBrimstoneView`** — creates `m_webDVH` over the now-hidden `m_graphDVH`; feeds structures + DVH curves to the page at the load and optimizer-update seams; applies edits posted back to the `Prescription`/`Structure` model.

## Protocol (documented in `DvhViewHtml.h`)
- **C++→JS:** `setStructures([{id,name,color,type,min,max,weight,priority}])`, `setDvh([{id,color,target,pts:[[dose,vol]]}])`
- **JS→C++:** `type|id|t`, `weight|id|w`, `interval|id|min|max`, `color|id|rrggbb`, `order|id0,id1,...`

## Notes
- The legacy `m_graphDVH` stays alive but hidden — its `CHistogramDataSeries` still produce the DVH curves forwarded to the page, so the existing pull-based data flow is untouched.
- Builds clean (Debug|x64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)