### PR TITLE
Consolidate RtModel Python bindings on pybind11 (Windows .pyd)

### DIFF
--- a/python/BUILD_NATIVE.md
+++ b/python/BUILD_NATIVE.md
@@ -1,0 +1,163 @@
+# Building the native `rtmodel_core` extension
+
+`rtmodel_core` is a [pybind11](https://pybind11.readthedocs.io) module that
+exposes the RtModel optimizer (`Prescription`, `DynamicCovarianceOptimizer`,
+`CVectorN`) to Python so you can drive the C++ objective function from
+NumPy/SciPy.
+
+> **Windows only.** RtModel is compiled against **MFC (Dynamic)**, **Intel
+> IPP**, **ITK 5.x** and **VNL**. None of these build with GCC/Clang, so the
+> extension is only producible with MSVC (v143, matching `RtModel.vcxproj`).
+> On Linux/macOS use the pure-Python `pybrimstone` package instead — it has no
+> compiled dependency.
+
+The binding source is [`rtmodel_bindings.cpp`](rtmodel_bindings.cpp); the build
+is driven by [`setup.py`](setup.py). The older Cython scaffold
+(`pybrimstone/core.pyx` / `core.pxd`) is **superseded** and no longer built.
+
+---
+
+## Prerequisites
+
+| Component | Notes |
+|-----------|-------|
+| Visual Studio 2022 | "Desktop development with C++" **and** the **MFC** component (v143) |
+| Python 3.8+ (64-bit) | Architecture must match the build (x64) |
+| pybind11, setuptools, wheel, numpy | `pip install pybind11 setuptools wheel numpy` |
+| ITK 5.x + VNL | Easiest via vcpkg: `vcpkg install itk:x64-windows` |
+| Intel IPP | oneAPI IPP (Community edition is free) |
+
+`setup.py` reads all external locations from environment variables, defaulting
+to the same vcpkg/oneAPI paths used by `RtModel.vcxproj` (x64):
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `VCPKG_ROOT` | `C:\vcpkg\installed\x64-windows` | vcpkg install tree (ITK + VNL) |
+| `ITK_VERSION` | `5.4` | ITK include folder suffix (`include\ITK-<ver>`) |
+| `IPP_ROOT` | `C:\Program Files (x86)\Intel\oneAPI\ipp\latest` | Intel IPP root |
+| `RTMODEL_LIB_DIR` | `<repo>\x64\Release` | folder containing `RtModel.lib` |
+| `ITK_LIB_DIR` | `%VCPKG_ROOT%\lib` | ITK/VNL import libraries |
+| `IPP_LIB_DIR` | `%IPP_ROOT%\lib` | IPP import libraries |
+
+Advanced overrides: `RTMODEL_INCLUDE_DIRS`, `RTMODEL_LIBRARY_DIRS`,
+`RTMODEL_ITK_LIBS`, `RTMODEL_IPP_LIBS` (all `;`-separated),
+`RTMODEL_SKIP_LIBCHECK=1` to bypass the `RtModel.lib` existence check.
+
+---
+
+## Build (two steps)
+
+RtModel is a **static library**, so build it first, then build the extension
+that links it. Run from an **"x64 Native Tools Command Prompt for VS 2022"** so
+`msbuild` and `cl` are on `PATH`.
+
+### 1. Build `RtModel.lib`
+
+```bat
+cd <repo>
+msbuild Brimstone_src.sln /t:RtModel /p:Configuration=Release /p:Platform=x64
+```
+
+This produces `x64\Release\RtModel.lib` (the default `RTMODEL_LIB_DIR`).
+
+### 2. Build and install the extension
+
+```bat
+cd <repo>\python
+pip install pybind11 setuptools wheel numpy
+pip install -e .
+```
+
+Or just compile in place:
+
+```bat
+python setup.py build_ext --inplace
+```
+
+If your ITK/IPP live elsewhere, set the variables first, e.g.:
+
+```bat
+set VCPKG_ROOT=D:\dev\vcpkg\installed\x64-windows
+set IPP_ROOT=C:\Program Files (x86)\Intel\oneAPI\ipp\2021.11
+pip install -e .
+```
+
+---
+
+## Smoke test
+
+```python
+import numpy as np
+import rtmodel_core as rc
+
+print(rc.__doc__)
+
+# CVectorN round-trips through NumPy
+v = rc.VectorN(4)
+for i in range(4):
+    v[i] = float(i)
+print(v.to_numpy())                 # [0. 1. 2. 3.]
+print(rc.VectorN.from_numpy(np.arange(3.0)).to_numpy())
+```
+
+Once you have a `Prescription` (built from a `Plan`; see the roadmap below),
+`PrescriptionWrapper` gives you a SciPy-friendly `(value, gradient)` callable:
+
+```python
+wrapper = rc.PrescriptionWrapper(presc)   # presc: rtmodel_core.Prescription
+n = wrapper.get_dimension()
+value, grad = wrapper.evaluate(np.zeros(n))
+
+from scipy.optimize import minimize
+res = minimize(lambda x: wrapper.evaluate(x), np.zeros(n), jac=True, method="L-BFGS-B")
+```
+
+---
+
+## What's exposed today
+
+`rtmodel_bindings.cpp` currently wraps:
+
+- **`VectorN`** — `CVectorN<double>` with `__len__`/`__getitem__`/`__setitem__`
+  and `to_numpy()` / `from_numpy()`.
+- **`Prescription`** — `get_number_of_unknowns()`, `set_gbin_var()`, and the
+  `operator()` objective (via `PrescriptionWrapper`).
+- **`PrescriptionWrapper`** — `evaluate(x) -> (value, grad)`,
+  `evaluate_value(x)`, `get_dimension()`.
+- **`ConjGradOptimizer`** (`DynamicCovarianceOptimizer`) — `minimize()`,
+  `set_adaptive_variance()`, `set_compute_free_energy()`,
+  `get_final_value()`, `get_entropy()`, `get_free_energy()`,
+  `get_adaptive_variance()`.
+
+## Not yet wrapped (next steps)
+
+There is no Python constructor for `Plan`/`Series`/`Structure` yet, so a
+`Prescription` still has to be created on the C++ side. To make the module
+usable end-to-end from Python, the follow-on work is:
+
+1. Bind `dH::Plan` construction and beam/beamlet setup.
+2. Bind `Series`/`Structure` plus ITK-volume ↔ NumPy conversion.
+3. Add a `Prescription(plan)` constructor and `AddStructureTerm` / `KLDivTerm`
+   so objectives can be defined from Python.
+4. Wire the optimizer callback (`OptimizerCallback`) through to a Python
+   `Callable` for live monitoring.
+
+See `../CYTHON_WRAPPER_DESIGN.md` for the full intended API (the class shapes
+there apply regardless of pybind11 vs Cython).
+
+---
+
+## Troubleshooting
+
+- **`fatal error C1189: WINDOWS.H already included. MFC apps must not #include
+  <windows.h>`** — the MFC headers must precede `Python.h`. `rtmodel_bindings.cpp`
+  already includes `<afx.h>` etc. first; don't reorder those above the pybind11
+  includes.
+- **`LNK2019: unresolved external symbol` for `itk...` / `vnl...`** — ITK/VNL
+  libraries weren't found. Check `ITK_LIB_DIR` and that the vcpkg triplet is
+  `x64-windows`. Pin an exact set with `RTMODEL_ITK_LIBS`.
+- **`LNK2038: mismatch detected for 'RuntimeLibrary'`** — everything must use
+  the dynamic release CRT (`/MD`). Rebuild `RtModel.lib` in **Release|x64**
+  (it uses `MultiThreadedDLL`) and use a release Python.
+- **`ImportError: DLL load failed`** — the ITK, IPP and MFC runtime DLLs must
+  be on `PATH` (or copied next to the `.pyd`) when importing.

--- a/python/RTMODEL_PYTHON_DLL_PLAN.md
+++ b/python/RTMODEL_PYTHON_DLL_PLAN.md
@@ -1,0 +1,156 @@
+# Plan: RtModel as a Python-callable DLL
+
+Goal: call the RtModel inverse-planning optimizer from Python, so plans can be
+driven and inspected with the NumPy/SciPy/matplotlib ecosystem instead of the
+MFC GUI.
+
+This document records the decision, the constraints that forced it, what has
+been done, and the remaining work. Companion docs:
+
+- [`BUILD_NATIVE.md`](BUILD_NATIVE.md) — how to build the extension.
+- [`../CYTHON_WRAPPER_DESIGN.md`](../CYTHON_WRAPPER_DESIGN.md) — the full
+  intended Python API (class shapes apply regardless of binding tech).
+
+---
+
+## 1. Decision
+
+**Bind with pybind11. Ship a Windows-only `.pyd`. Keep RtModel unchanged.**
+
+| Option | Verdict |
+|--------|---------|
+| **ctypes** | Rejected. Speaks only the C ABI (flat `extern "C"`, primitive types). RtModel is C++ with templates (`CVectorN<>`), overloaded `operator()`, inheritance and MFC objects. You'd hand-write a C shim around every call first, so ctypes just adds a fragile layer. |
+| **Cython** | Rejected for this job. Best when writing *new* hot-loop code; for *wrapping existing* C++ it means a `.pyx`/`.pxd` pair kept in sync with the headers by hand (the old scaffold had already drifted out of sync). |
+| **pybind11** | **Chosen.** Header-only, wraps existing C++ (STL, templates, overloads) directly, first-class NumPy buffer protocol, no separate declaration file. A working wrapper already existed in the repo. |
+
+### Why Windows-only
+
+RtModel is not a portable numerical library. MFC/native types appear in the
+**public** members and method signatures of exactly the classes to bind:
+
+| Class | Native leakage in its interface |
+|-------|---------------------------------|
+| `Prescription` | `CTypedPtrMap<CMapPtrToPtr,…>`, `CArray<BOOL,BOOL>` |
+| `Plan` | `CTypedPtrMap<CMapStringToOb, CString, CHistogram*>` |
+| `VOITerm` | `CArray<BOOL,BOOL>` in the pure-virtual `Eval()` |
+| `VectorN` | `CString ToString()`, plus Intel **IPP** (`ipp.h`) |
+
+Plus `stdafx.h` pulls in `afx.h`/`afxwin.h`/`afxtempl.h`/`atlcoll.h`, and the
+`.cpp`s lean on **VNL** and **ITK** throughout. `#include <afx.h>` cannot be
+compiled by GCC/Clang — MFC is MSVC-only — so a portable `.so` is impossible
+without stripping MFC out of the public surface. That refactor was explicitly
+deferred; the near-term target is a Windows `.pyd`.
+
+A **de-MFC refactor** (replace `CArray`/`CTypedPtrMap`/`CString` with
+`std::vector`/`std::map`/`std::string`, add a scalar fallback for IPP) remains
+the correct long-term path to Linux/macOS. It is out of scope for this plan but
+noted so the door stays open.
+
+---
+
+## 2. Architecture
+
+```
+Python (NumPy / SciPy / matplotlib)
+        │  import rtmodel_core
+        ▼
+rtmodel_core.pyd                     ← pybind11 module (this work)
+        │  rtmodel_bindings.cpp
+        ▼
+RtModel.lib  (static, built by RtModel.vcxproj, unchanged)
+        │
+        ├─ MFC (Dynamic)     ├─ Intel IPP
+        └─ ITK 5.x + VNL
+```
+
+RtModel stays a **static library**. The extension compiles only the thin
+binding TU (`rtmodel_bindings.cpp`) and **links** `RtModel.lib` + ITK/VNL/IPP.
+This avoids recompiling every RtModel source (each needs the `stdafx.h`
+precompiled header and the full dependency stack) inside the Python build.
+
+### Build model (two steps)
+
+1. `msbuild Brimstone_src.sln /t:RtModel /p:Configuration=Release /p:Platform=x64`
+   → `x64/Release/RtModel.lib`
+2. `pip install -e .` (in `python/`) → compiles + links `rtmodel_core.pyd`
+
+All external paths come from environment variables that default to the
+vcpkg/oneAPI layout already in `RtModel.vcxproj`. Details in `BUILD_NATIVE.md`.
+
+---
+
+## 3. Status
+
+### Done
+
+- [x] Chose pybind11; consolidated onto `rtmodel_bindings.cpp` as the single
+      native path.
+- [x] Fixed the two build/import blockers in `rtmodel_bindings.cpp`:
+  - MFC headers now precede `pybind11`/`Python.h` (else `afx.h` errors because
+    `Python.h` has already included `windows.h`).
+  - Registered the abstract `DynamicCovarianceCostFunction` base, so the
+    `Prescription` base is valid to pybind11 and a `Prescription` can be passed
+    where the optimizer constructor wants a `DynamicCovarianceCostFunction*`.
+- [x] Rewrote `setup.py` as a pybind11 Windows build (MFC Dynamic, `/std:c++17`,
+      Unicode, `USE_IPP`/`USE_RTOPT`/`NOMINMAX`, links `RtModel.lib` + ITK/VNL/IPP,
+      env-var-driven paths, non-Windows guard).
+- [x] `pyproject.toml` builds against pybind11; `BUILD_NATIVE.md` written.
+- [x] Marked the superseded Cython scaffold (`pybrimstone/core.pyx`/`.pxd`).
+
+### Currently exposed to Python
+
+- `VectorN` (`CVectorN<double>`) with NumPy round-trip.
+- `Prescription` — `get_number_of_unknowns()`, `set_gbin_var()`.
+- `PrescriptionWrapper` — `evaluate(x) -> (value, grad)`, `evaluate_value(x)`,
+  `get_dimension()` (SciPy-friendly).
+- `ConjGradOptimizer` (`DynamicCovarianceOptimizer`) — `minimize()`,
+  `set_adaptive_variance()`, `set_compute_free_energy()`, `get_final_value()`,
+  `get_entropy()`, `get_free_energy()`, `get_adaptive_variance()`.
+
+### Not verified
+
+- Not compiled: MFC/ITK/IPP require MSVC; correctness comes from
+  cross-referencing headers and `RtModel.vcxproj`, not a green build. First
+  build on a real Windows toolchain will shake out remaining details.
+
+---
+
+## 4. Roadmap to end-to-end use
+
+Today a `Prescription` must still be constructed on the C++ side (no Python
+constructors for the data model yet). To make the module usable start-to-finish
+from Python:
+
+### Phase A — Data model construction
+1. Bind `dH::Plan` construction and beam / beamlet setup.
+2. Bind `Series` / `Structure`, plus ITK-volume ↔ NumPy conversion
+   (image buffer sharing without copies where possible).
+3. Add a `Prescription(plan)` constructor and `AddStructureTerm` / `KLDivTerm`
+   so objectives can be defined from Python.
+
+### Phase B — Optimization loop
+4. Wire the `OptimizerCallback` through to a Python `Callable` for live
+   monitoring (iteration, cost, gradient norm, current weights, dose, sigma).
+5. Expose `PlanOptimizer` (multi-scale pyramid) and return an
+   `OptimizationResult`.
+
+### Phase C — Validation & ergonomics
+6. Cross-check the pybind11 path against the pure-Python `pybrimstone`
+   reimplementation (same inputs → same cost/gradient) as a correctness oracle.
+7. Package wheels (cibuildwheel on Windows), pin exact ITK/IPP lib sets.
+8. Optional DICOM I/O and pymedphys/matplotlib visualization helpers.
+
+### Longer term (separate track)
+9. De-MFC the RtModel public surface → cross-platform (Linux/macOS) builds.
+
+---
+
+## 5. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| MFC + `Python.h` include-order / CRT conflicts | Documented; MFC-first ordering and `/MD` everywhere. |
+| ITK is highly modular — many link deps | `setup.py` globs all ITK/VNL libs; `RTMODEL_ITK_LIBS` pins an exact set. |
+| Runtime DLL loading (ITK/IPP/MFC) | Ship DLLs beside the `.pyd` or on `PATH`; document. |
+| API drift between C++ and pure-Python port | Phase C uses the port as a numerical oracle. |
+| Windows-only limits adoption | De-MFC track (Phase 9) keeps cross-platform open. |

--- a/python/pybrimstone/core.pxd
+++ b/python/pybrimstone/core.pxd
@@ -6,6 +6,10 @@ Cython declarations for Brimstone C++ classes
 
 This file declares the C++ classes and methods that will be wrapped
 for Python access.
+
+SUPERSEDED -- the native binding path is now pybind11 (../rtmodel_bindings.cpp).
+This file is no longer built and some declarations here diverge from the actual
+RtModel headers. Kept for reference only; see ../BUILD_NATIVE.md.
 """
 
 from libcpp cimport bool

--- a/python/pybrimstone/core.pyx
+++ b/python/pybrimstone/core.pyx
@@ -5,6 +5,11 @@
 Cython implementation of Python wrappers for Brimstone C++ classes
 
 This file implements the Python-facing classes that wrap the C++ implementation.
+
+SUPERSEDED -- the native binding path is now pybind11 (../rtmodel_bindings.cpp,
+built by ../setup.py into the `rtmodel_core` module). This .pyx/.pxd pair is no
+longer part of the build and its declarations do not match the current RtModel
+headers. Kept only for reference; see ../BUILD_NATIVE.md.
 """
 
 import numpy as np

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "Cython>=0.29", "numpy>=1.20"]
+# Native bindings (rtmodel_core, Windows-only) are built with pybind11.
+# On Linux/macOS the compiled extension is skipped and only the pure-Python
+# pybrimstone package is installed.
+requires = ["setuptools>=45", "wheel", "pybind11>=2.10", "numpy>=1.20"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -30,7 +33,6 @@ classifiers = [
 
 dependencies = [
     "numpy>=1.20",
-    "cython>=0.29",
 ]
 
 [project.optional-dependencies]

--- a/python/rtmodel_bindings.cpp
+++ b/python/rtmodel_bindings.cpp
@@ -1,6 +1,24 @@
 // Copyright (C) 2nd Messenger Systems
 // pybind11 bindings for RtModel
+//
+// Windows-only. RtModel is built against MFC (Dynamic), Intel IPP, ITK and
+// VNL, so this extension can only be compiled with MSVC. See BUILD_NATIVE.md.
+//
+// Include ORDER matters: MFC's <afx.h> refuses to compile if <windows.h> was
+// already pulled in (Python.h includes it). So the MFC headers MUST come
+// before <pybind11/pybind11.h> (which includes Python.h). The RtModel public
+// headers (Prescription.h, Plan.h, VectorN.h ...) reference CString, CArray
+// and CTypedPtrMap without including MFC themselves -- they rely on the
+// translation unit having already included these, exactly as stdafx.h does.
 
+// --- MFC first (mirrors RtModel/stdafx.h) -----------------------------------
+#include <afx.h>
+#include <afxwin.h>
+#include <afxdisp.h>
+#include <afxtempl.h>
+#include <atlcoll.h>
+
+// --- then pybind11 / Python -------------------------------------------------
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
@@ -130,6 +148,14 @@ PYBIND11_MODULE(rtmodel_core, m) {
         })
         .def("to_numpy", &vector_to_numpy)
         .def_static("from_numpy", &numpy_to_vector);
+
+    // Register the abstract base BEFORE any derived class names it. pybind11
+    // requires every declared base to be a registered type, and registering it
+    // also teaches pybind11 the Prescription -> DynamicCovarianceCostFunction
+    // relationship, so a Prescription can be passed where the optimizer
+    // constructor expects a DynamicCovarianceCostFunction*. No constructor is
+    // exposed because the class is abstract (pure-virtual operator()).
+    py::class_<DynamicCovarianceCostFunction>(m, "DynamicCovarianceCostFunction");
 
     // Expose Prescription (base objective function)
     py::class_<Prescription, DynamicCovarianceCostFunction>(m, "Prescription")

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,112 +1,196 @@
 """
-Setup script for pybrimstone - Python wrapper for Brimstone optimization algorithm
+Build script for rtmodel_core - pybind11 bindings for the RtModel C++ library.
 
 Copyright (C) 2nd Messenger Systems - U. S. Patent 7,369,645
+
+WINDOWS ONLY. RtModel is built against MFC (Dynamic linkage), Intel IPP, ITK
+and VNL, none of which compile with GCC/Clang, so this extension can only be
+produced with MSVC (the v143 toolset, matching RtModel.vcxproj).
+
+Build model
+-----------
+RtModel itself is a *static library* (RtModel/RtModel.vcxproj -> RtModel.lib).
+Rather than recompiling every RtModel .cpp here (each needs the stdafx.h
+precompiled header, IPP, ITK, ...), this script compiles only the thin binding
+translation unit `rtmodel_bindings.cpp` and *links the prebuilt RtModel.lib*
+plus the ITK/VNL/IPP import libraries it depends on.
+
+So the full build is two steps:
+
+  1) Build RtModel.lib with MSBuild, e.g. from a "x64 Native Tools" prompt:
+         msbuild ..\Brimstone_src.sln /t:RtModel /p:Configuration=Release /p:Platform=x64
+  2) Build + install this extension:
+         pip install -e .
+
+All external paths are read from environment variables (with vcpkg defaults
+that mirror RtModel.vcxproj's x64 configuration) so the build is portable
+across machines without editing this file. See BUILD_NATIVE.md.
 """
 
+import glob
 import os
 import sys
 from pathlib import Path
 
-import numpy
-from Cython.Build import cythonize
-from setuptools import Extension, setup
+from setuptools import setup
 
-# Determine platform-specific settings
-is_windows = sys.platform.startswith("win")
-is_linux = sys.platform.startswith("linux")
+try:
+    from pybind11.setup_helpers import Pybind11Extension, build_ext
+except ImportError:  # pragma: no cover - build dependency
+    sys.exit(
+        "pybind11 is required to build rtmodel_core. Install the build "
+        "dependencies first:\n    pip install pybind11 setuptools wheel numpy"
+    )
 
-# Base paths
-PROJECT_ROOT = Path(__file__).parent.parent
-RTMODEL_DIR = PROJECT_ROOT / "RtModel"
-RTMODEL_INCLUDE = RTMODEL_DIR / "include"
-VECMAT_DIR = PROJECT_ROOT / "VecMat"
-GRAPH_DIR = PROJECT_ROOT / "Graph"
+# ---------------------------------------------------------------------------
+# Platform guard -- fail early and clearly rather than deep inside the compiler.
+# ---------------------------------------------------------------------------
+if not sys.platform.startswith("win"):
+    sys.exit(
+        "rtmodel_core can only be built on Windows with MSVC.\n"
+        "RtModel depends on MFC, Intel IPP, ITK and VNL, which are not\n"
+        "available to GCC/Clang. On Linux/macOS use the pure-Python\n"
+        "'pybrimstone' package instead (no compiled extension required)."
+    )
 
-# Common include directories
+
+def env_path(name: str, default: str) -> str:
+    """Return an environment override or the vcpkg/oneAPI default."""
+    return os.environ.get(name, default)
+
+
+def env_paths(name: str, defaults):
+    """Semicolon-separated env override, else the provided default list."""
+    raw = os.environ.get(name)
+    if raw:
+        return [p for p in raw.split(os.pathsep) if p]
+    return list(defaults)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent  # repo root (dH/)
+RTMODEL_INCLUDE = str(PROJECT_ROOT / "RtModel" / "include")
+
+# --- Third-party locations (defaults match RtModel.vcxproj, x64) ------------
+VCPKG_ROOT = env_path("VCPKG_ROOT", r"C:\vcpkg\installed\x64-windows")
+IPP_ROOT = env_path(
+    "IPP_ROOT", r"C:\Program Files (x86)\Intel\oneAPI\ipp\latest"
+)
+
+itk_version = os.environ.get("ITK_VERSION", "5.4")
+
 include_dirs = [
-    str(RTMODEL_INCLUDE),
-    str(VECMAT_DIR),
-    str(GRAPH_DIR),
-    numpy.get_include(),
+    RTMODEL_INCLUDE,
+    # ITK + VNL/VXL (vcpkg layout)
+    os.path.join(VCPKG_ROOT, "include", f"ITK-{itk_version}"),
+    os.path.join(VCPKG_ROOT, "include", "vxl", "core"),
+    os.path.join(VCPKG_ROOT, "include", "vxl", "vcl"),
+    os.path.join(VCPKG_ROOT, "include"),
+    # Intel IPP
+    os.path.join(IPP_ROOT, "include"),
+    os.path.join(IPP_ROOT, "include", "ipp"),
+]
+# Allow full override / extension of the include search path.
+include_dirs = env_paths("RTMODEL_INCLUDE_DIRS", include_dirs)
+
+# --- Library search paths ---------------------------------------------------
+# RtModel.lib default output: <solution>/x64/Release (RtModel.vcxproj OutDir).
+RTMODEL_LIB_DIR = env_path(
+    "RTMODEL_LIB_DIR", str(PROJECT_ROOT / "x64" / "Release")
+)
+ITK_LIB_DIR = env_path("ITK_LIB_DIR", os.path.join(VCPKG_ROOT, "lib"))
+IPP_LIB_DIR = env_path("IPP_LIB_DIR", os.path.join(IPP_ROOT, "lib"))
+
+library_dirs = env_paths(
+    "RTMODEL_LIBRARY_DIRS", [RTMODEL_LIB_DIR, ITK_LIB_DIR, IPP_LIB_DIR]
+)
+
+
+def lib_names(directory: str, patterns):
+    """Collect .lib basenames (without extension) matching any glob pattern."""
+    names = []
+    for pat in patterns:
+        for path in glob.glob(os.path.join(directory, pat)):
+            names.append(Path(path).stem)
+    return sorted(set(names))
+
+
+# RtModel static library. The name is fixed; presence of the .lib is checked so
+# the failure is a clear message rather than an obscure linker error.
+libraries = ["RtModel"]
+rtmodel_lib = os.path.join(RTMODEL_LIB_DIR, "RtModel.lib")
+if not os.path.exists(rtmodel_lib) and "RTMODEL_SKIP_LIBCHECK" not in os.environ:
+    sys.exit(
+        f"RtModel.lib not found at {rtmodel_lib}.\n"
+        "Build it first (step 1 in this file's docstring), or point\n"
+        "RTMODEL_LIB_DIR at the directory that contains RtModel.lib.\n"
+        "Set RTMODEL_SKIP_LIBCHECK=1 to bypass this check."
+    )
+
+# ITK is highly modular; link every ITK/VNL/ITKSYS import library found so the
+# many symbols RtModel pulls in resolve. Over-linking is harmless for a static
+# dependency. Users can pin an exact list via RTMODEL_ITK_LIBS.
+itk_libs = os.environ.get("RTMODEL_ITK_LIBS")
+if itk_libs:
+    libraries += [x for x in itk_libs.split(os.pathsep) if x]
+else:
+    libraries += lib_names(
+        ITK_LIB_DIR, ["ITK*.lib", "itk*.lib", "vnl*.lib", "vcl*.lib", "v3p*.lib"]
+    )
+
+# Intel IPP import libraries used by CVectorN (USE_IPP): core + signal + image.
+ipp_libs = os.environ.get("RTMODEL_IPP_LIBS")
+if ipp_libs:
+    libraries += [x for x in ipp_libs.split(os.pathsep) if x]
+else:
+    found_ipp = lib_names(IPP_LIB_DIR, ["ippcore*.lib", "ipps*.lib", "ippi*.lib", "ippvm*.lib"])
+    libraries += found_ipp if found_ipp else ["ippcore", "ipps", "ippi", "ippvm"]
+
+# ---------------------------------------------------------------------------
+# Compiler / preprocessor settings -- mirror RtModel.vcxproj (Release|x64).
+#   MFC Dynamic  -> _AFXDLL, and the MFC headers pragma-link the right DLLs.
+#   Unicode      -> UNICODE / _UNICODE (CharacterSet=Unicode).
+#   Runtime      -> /MD (MultiThreadedDLL), which is also Python's release CRT,
+#                   so RtModel.lib, MFC and the Python extension all agree.
+# ---------------------------------------------------------------------------
+define_macros = [
+    ("WIN32", None),
+    ("_WINDOWS", None),
+    ("NDEBUG", None),
+    ("USE_IPP", None),
+    ("USE_RTOPT", None),
+    ("NOMINMAX", None),
+    ("UNICODE", None),
+    ("_UNICODE", None),
+    ("_AFXDLL", None),          # MFC shared (Dynamic) linkage
+    ("VERSION_INFO", '"0.1.0"'),
 ]
 
-# Common library directories
-library_dirs = []
+extra_compile_args = [
+    "/std:c++17",   # RtModel.vcxproj LanguageStandard (x64)
+    "/EHsc",
+    "/bigobj",      # MFC + ITK template instantiations blow past 64k sections
+    "/MD",          # dynamic release CRT (must match RtModel.lib + MFC + Python)
+    "/wd4996",      # silence CRT/STL deprecation noise from old RtModel code
+]
 
-# Common libraries to link
-libraries = []
-
-# Compiler flags
-extra_compile_args = []
-extra_link_args = []
-
-if is_windows:
-    # Windows-specific settings
-    extra_compile_args = [
-        "/std:c++14",
-        "/EHsc",
-        "/D_USE_MATH_DEFINES",
-        "/DUSE_RTOPT",
-        "/DWIN32",
-        "/D_WINDOWS",
-    ]
-    # Add ITK paths (adjust as needed for your system)
-    # include_dirs.append("C:/Program Files/ITK/include")
-    # library_dirs.append("C:/Program Files/ITK/lib")
-
-elif is_linux:
-    # Linux-specific settings
-    extra_compile_args = [
-        "-std=c++14",
-        "-DUSE_RTOPT",
-        "-fPIC",
-    ]
-    extra_link_args = ["-Wl,-rpath,$ORIGIN"]
-
-# Define extensions
-extensions = [
-    Extension(
-        name="pybrimstone.core",
-        sources=[
-            "pybrimstone/core.pyx",
-            # C++ source files to compile
-            str(RTMODEL_DIR / "PlanOptimizer.cpp"),
-            str(RTMODEL_DIR / "ConjGradOptimizer.cpp"),
-            str(RTMODEL_DIR / "Prescription.cpp"),
-            str(RTMODEL_DIR / "KLDivTerm.cpp"),
-            str(RTMODEL_DIR / "VOITerm.cpp"),
-            str(RTMODEL_DIR / "ObjectiveFunction.cpp"),
-            str(RTMODEL_DIR / "PlanPyramid.cpp"),
-            str(RTMODEL_DIR / "Plan.cpp"),
-            str(RTMODEL_DIR / "Beam.cpp"),
-            str(RTMODEL_DIR / "Structure.cpp"),
-            str(RTMODEL_DIR / "Series.cpp"),
-            str(RTMODEL_DIR / "Histogram.cpp"),
-            str(RTMODEL_DIR / "HistogramGradient.cpp"),
-        ],
+ext_modules = [
+    Pybind11Extension(
+        "rtmodel_core",
+        sources=["rtmodel_bindings.cpp"],
         include_dirs=include_dirs,
         library_dirs=library_dirs,
         libraries=libraries,
+        define_macros=define_macros,
         extra_compile_args=extra_compile_args,
-        extra_link_args=extra_link_args,
+        cxx_std=17,
         language="c++",
     ),
 ]
 
-# Cythonize extensions
-ext_modules = cythonize(
-    extensions,
-    compiler_directives={
-        "language_level": "3",
-        "embedsignature": True,
-        "boundscheck": False,
-        "wraparound": False,
-    },
-)
-
-# Run setup
+# Package metadata (name, version, dependencies, ...) lives in pyproject.toml.
+# setup.py only contributes the compiled extension so the two don't collide.
 setup(
     ext_modules=ext_modules,
+    cmdclass={"build_ext": build_ext},
     zip_safe=False,
 )


### PR DESCRIPTION
Make the pybind11 wrapper the single, buildable native binding path for
RtModel and wire it into an MSVC build, replacing the incomplete Cython
scaffold.

- rtmodel_bindings.cpp: include the MFC headers before pybind11/Python.h
  (afx.h errors out if windows.h, pulled in by Python.h, is included first),
  and register the abstract DynamicCovarianceCostFunction base so the
  Prescription base is valid and a Prescription can be passed to the
  optimizer constructor.
- setup.py: rewrite as a pybind11 build of rtmodel_core. Windows-only guard,
  MFC Dynamic (_AFXDLL), /std:c++17, Unicode, USE_IPP/USE_RTOPT/NOMINMAX,
  links the prebuilt RtModel.lib plus ITK/VNL/IPP; all external paths come
  from env vars defaulting to the vcpkg/oneAPI layout in RtModel.vcxproj.
- pyproject.toml: build against pybind11 instead of Cython.
- BUILD_NATIVE.md: two-step build (RtModel.lib, then the extension), env
  vars, smoke test, current API surface, next steps, troubleshooting.
- Mark core.pyx/core.pxd as superseded (no longer built).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FSQuyJ32sPydpHhJ6SWPYW