### PR TITLE
Refactor: remove MFC/ATL, use std C++ types & ARM64 cfgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,9 @@
 __pycache__/
 .vscode/
 # build output: exe/lib and the DLLs + *.dat kernels the post-build step
-#	copies in (matches x64 at the repo root and nested under each project)
+#	copies in (matches x64/ARM64 at the repo root and nested under each project)
 x64/
+ARM64/
 *.idb
 *.pdb
 venv/

--- a/Brimstone/Brimstone.vcxproj
+++ b/Brimstone/Brimstone.vcxproj
@@ -17,6 +17,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{80AB664E-B56A-4A59-91D6-A8201FC00859}</ProjectGuid>
@@ -26,30 +34,49 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <!-- ARM64: native build. No Intel IPP (x86-only), so USE_IPP is left undefined and
+       VectorOps.h falls back to its generic template implementations. VCToolsVersion is
+       pinned because MFC/ATL ships only with 14.51 here, not the default 14.52. -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v145</PlatformToolset>
+    <VCToolsVersion>14.51.36231</VCToolsVersion>
+    <UseOfMfc>Dynamic</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v145</PlatformToolset>
+    <VCToolsVersion>14.51.36231</VCToolsVersion>
+    <UseOfMfc>Dynamic</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -64,6 +91,12 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -87,6 +120,16 @@
     <GenerateManifest>true</GenerateManifest>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
@@ -300,6 +343,103 @@ copy "C:\Program Files (x86)\Intel\oneAPI\ipp\latest\bin\ipps*.dll" $(OutDir)
 copy "C:\Program Files (x86)\Intel\oneAPI\ipp\latest\bin\ippcore*.dll" $(OutDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <Midl>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>false</MkTypLibCompatible>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>
+        ..\Graph\include;
+        ..\RtModel\include;
+        ..\XMLLogging;
+        C:\vcpkg\installed\arm64-windows\include\ITK-5.4;
+        C:\vcpkg\installed\arm64-windows\include\vxl\core;
+        C:\vcpkg\installed\arm64-windows\include\vxl\vcl;
+        C:\vcpkg\installed\arm64-windows\include\eigen3;
+        C:\vcpkg\installed\arm64-windows\include;
+        %(AdditionalIncludeDirectories)
+      </AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;SBYTE_DEFINED;USE_RTOPT;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>dcmimgle.lib;dcmdata.lib;oflog.lib;ofstd.lib;ITKCommon-5.4.lib;ITKTransform-5.4.lib;ITKSpatialObjects-5.4.lib;vnl_algo.lib;v3p_netlib.lib;vnl.lib;vcl.lib;itksys-5.4.lib;WebView2Loader.dll.lib;ws2_32.lib;netapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>C:\vcpkg\installed\arm64-windows\debug\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <RandomizedBaseAddress>true</RandomizedBaseAddress>
+    </Link>
+    <PostBuildEvent>
+      <Message>copy the kernel data and vcpkg runtime DLLs</Message>
+      <Command>copy *kernel.dat $(OutDir)
+copy C:\vcpkg\installed\arm64-windows\debug\bin\*.dll $(OutDir)</Command>
+    </PostBuildEvent>
+    <Manifest>
+      <EnableDpiAwareness>false</EnableDpiAwareness>
+    </Manifest>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <Midl>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>false</MkTypLibCompatible>
+    </Midl>
+    <ClCompile>
+      <AdditionalIncludeDirectories>
+        ..\Graph\include;
+        ..\RtModel\include;
+        ..\XMLLogging;
+        C:\vcpkg\installed\arm64-windows\include\ITK-5.4;
+        C:\vcpkg\installed\arm64-windows\include\vxl\core;
+        C:\vcpkg\installed\arm64-windows\include\vxl\vcl;
+        C:\vcpkg\installed\arm64-windows\include\eigen3;
+        C:\vcpkg\installed\arm64-windows\include;
+        %(AdditionalIncludeDirectories)
+      </AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;SBYTE_DEFINED;USE_RTOPT;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>dcmimgle.lib;dcmdata.lib;oflog.lib;ofstd.lib;ITKCommon-5.4.lib;ITKTransform-5.4.lib;ITKSpatialObjects-5.4.lib;vnl_algo.lib;v3p_netlib.lib;vnl.lib;vcl.lib;itksys-5.4.lib;WebView2Loader.dll.lib;ws2_32.lib;netapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>C:\vcpkg\installed\arm64-windows\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <RandomizedBaseAddress>true</RandomizedBaseAddress>
+    </Link>
+    <PostBuildEvent>
+      <Message>copy the kernel data and vcpkg runtime DLLs</Message>
+      <Command>copy *kernel.dat $(OutDir)
+copy C:\vcpkg\installed\arm64-windows\bin\*.dll $(OutDir)</Command>
+    </PostBuildEvent>
+    <Manifest>
+      <EnableDpiAwareness>false</EnableDpiAwareness>
+    </Manifest>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Brimstone.cpp" />
     <ClCompile Include="BrimstoneDoc.cpp" />
@@ -328,6 +468,8 @@ copy "C:\Program Files (x86)\Intel\oneAPI\ipp\latest\bin\ippcore*.dll" $(OutDir)
       <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Async</ExceptionHandling>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="PrescriptionToolbar.cpp" />
     <ClCompile Include="SeriesDicomImporter.cpp" />
@@ -336,6 +478,8 @@ copy "C:\Program Files (x86)\Intel\oneAPI\ipp\latest\bin\ippcore*.dll" $(OutDir)
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Brimstone/StdAfx.h
+++ b/Brimstone/StdAfx.h
@@ -43,9 +43,11 @@ USES_FMT;
 // math include
 #include <math.h>
 
-// IPP includes
+// IPP includes (Intel-only; ARM64 builds leave USE_IPP undefined)
+#ifdef USE_IPP
 #include <ipps.h>
 #include <ippcv.h>
+#endif
 
 // utility macros
 #include <UtilMacros.h>

--- a/Brimstone_src.sln
+++ b/Brimstone_src.sln
@@ -10,6 +10,7 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|Mixed Platforms = Debug|Mixed Platforms
+		Debug|ARM64 = Debug|ARM64
 		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
 		MinSizeRel|Any CPU = MinSizeRel|Any CPU
@@ -18,6 +19,7 @@ Global
 		MinSizeRel|x64 = MinSizeRel|x64
 		Release|Any CPU = Release|Any CPU
 		Release|Mixed Platforms = Release|Mixed Platforms
+		Release|ARM64 = Release|ARM64
 		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
 		RelWithDebInfo|Any CPU = RelWithDebInfo|Any CPU
@@ -26,6 +28,10 @@ Global
 		RelWithDebInfo|x64 = RelWithDebInfo|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7C848FBB-2C50-4F47-81C9-B872E9B504C1}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{7C848FBB-2C50-4F47-81C9-B872E9B504C1}.Debug|ARM64.Build.0 = Debug|ARM64
+		{7C848FBB-2C50-4F47-81C9-B872E9B504C1}.Release|ARM64.ActiveCfg = Release|ARM64
+		{7C848FBB-2C50-4F47-81C9-B872E9B504C1}.Release|ARM64.Build.0 = Release|ARM64
 		{7C848FBB-2C50-4F47-81C9-B872E9B504C1}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{7C848FBB-2C50-4F47-81C9-B872E9B504C1}.Debug|Mixed Platforms.ActiveCfg = Debug|x64
 		{7C848FBB-2C50-4F47-81C9-B872E9B504C1}.Debug|Mixed Platforms.Build.0 = Debug|x64
@@ -54,6 +60,10 @@ Global
 		{7C848FBB-2C50-4F47-81C9-B872E9B504C1}.RelWithDebInfo|Win32.Build.0 = Release|Win32
 		{7C848FBB-2C50-4F47-81C9-B872E9B504C1}.RelWithDebInfo|x64.ActiveCfg = Release|x64
 		{7C848FBB-2C50-4F47-81C9-B872E9B504C1}.RelWithDebInfo|x64.Build.0 = Release|x64
+		{80AB664E-B56A-4A59-91D6-A8201FC00859}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{80AB664E-B56A-4A59-91D6-A8201FC00859}.Debug|ARM64.Build.0 = Debug|ARM64
+		{80AB664E-B56A-4A59-91D6-A8201FC00859}.Release|ARM64.ActiveCfg = Release|ARM64
+		{80AB664E-B56A-4A59-91D6-A8201FC00859}.Release|ARM64.Build.0 = Release|ARM64
 		{80AB664E-B56A-4A59-91D6-A8201FC00859}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{80AB664E-B56A-4A59-91D6-A8201FC00859}.Debug|Mixed Platforms.ActiveCfg = Debug|x64
 		{80AB664E-B56A-4A59-91D6-A8201FC00859}.Debug|Mixed Platforms.Build.0 = Debug|x64
@@ -82,6 +92,10 @@ Global
 		{80AB664E-B56A-4A59-91D6-A8201FC00859}.RelWithDebInfo|Win32.Build.0 = Release|Win32
 		{80AB664E-B56A-4A59-91D6-A8201FC00859}.RelWithDebInfo|x64.ActiveCfg = Release|x64
 		{80AB664E-B56A-4A59-91D6-A8201FC00859}.RelWithDebInfo|x64.Build.0 = Release|x64
+		{21687638-397B-43A4-B462-C71A741C0C04}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{21687638-397B-43A4-B462-C71A741C0C04}.Debug|ARM64.Build.0 = Debug|ARM64
+		{21687638-397B-43A4-B462-C71A741C0C04}.Release|ARM64.ActiveCfg = Release|ARM64
+		{21687638-397B-43A4-B462-C71A741C0C04}.Release|ARM64.Build.0 = Release|ARM64
 		{21687638-397B-43A4-B462-C71A741C0C04}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{21687638-397B-43A4-B462-C71A741C0C04}.Debug|Mixed Platforms.ActiveCfg = Debug|x64
 		{21687638-397B-43A4-B462-C71A741C0C04}.Debug|Mixed Platforms.Build.0 = Debug|x64

--- a/Graph/Graph.vcxproj
+++ b/Graph/Graph.vcxproj
@@ -17,6 +17,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{21687638-397B-43A4-B462-C71A741C0C04}</ProjectGuid>
@@ -26,29 +34,47 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <!-- ARM64: native build. No Intel IPP (x86-only), so USE_IPP is left undefined and
+       VectorOps.h falls back to its generic template implementations. VCToolsVersion is
+       pinned because MFC/ATL ships only with 14.51 here, not the default 14.52. -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v145</PlatformToolset>
+    <VCToolsVersion>14.51.36231</VCToolsVersion>
+    <UseOfMfc>Dynamic</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v145</PlatformToolset>
+    <VCToolsVersion>14.51.36231</VCToolsVersion>
+    <UseOfMfc>Dynamic</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -63,6 +89,12 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -82,6 +114,14 @@
     <IntDir>$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
@@ -211,6 +251,48 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>
+        .\include;
+        ..\RtModel\include;
+        C:\vcpkg\installed\arm64-windows\include\ITK-5.4;
+        C:\vcpkg\installed\arm64-windows\include\vxl\core;
+        C:\vcpkg\installed\arm64-windows\include\vxl\vcl;
+        C:\vcpkg\installed\arm64-windows\include\eigen3;
+        C:\vcpkg\installed\arm64-windows\include;
+        %(AdditionalIncludeDirectories)
+      </AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;USE_RTOPT;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>
+        .\include;
+        ..\RtModel\include;
+        C:\vcpkg\installed\arm64-windows\include\ITK-5.4;
+        C:\vcpkg\installed\arm64-windows\include\vxl\core;
+        C:\vcpkg\installed\arm64-windows\include\vxl\vcl;
+        C:\vcpkg\installed\arm64-windows\include\eigen3;
+        C:\vcpkg\installed\arm64-windows\include;
+        %(AdditionalIncludeDirectories)
+      </AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;USE_RTOPT;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="DataSeries.cpp" />
     <ClCompile Include="Dib.cpp" />
@@ -221,6 +303,8 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="TargetDVHSeries.cpp" />
   </ItemGroup>

--- a/RtModel/Beam.cpp
+++ b/RtModel/Beam.cpp
@@ -147,7 +147,7 @@ void
 	Beam::OnIntensityMapChanged() 
 {
 	// must be odd-sized
-	ASSERT(m_vBeamletWeights->GetBufferedRegion().GetSize()[0] % 2 == 1);
+	assert(m_vBeamletWeights->GetBufferedRegion().GetSize()[0] % 2 == 1);
 
 	// set up the number of beamelts
 	if (m_vBeamletWeights->GetBufferedRegion().GetSize()[0] != m_arrBeamlets.size())

--- a/RtModel/BeamDoseCalc.cpp
+++ b/RtModel/BeamDoseCalc.cpp
@@ -35,7 +35,7 @@ void
 	// Calculates pencil beams given the density matrix
 {
 	// TODO: check that dose matrix is initialized
-	ASSERT(m_pBeam->m_dose->GetBufferedRegion().GetSize()[0] > 0);
+	assert(m_pBeam->m_dose->GetBufferedRegion().GetSize()[0] > 0);
 
 	m_densityRep = VolumeReal::New();
 	ConformTo<VOXEL_REAL,3>(m_pBeam->m_dose, m_densityRep);
@@ -117,10 +117,7 @@ void CBeamDoseCalc::CalcBeamlet(int nBeamlet)
 
 	// convolve terma with energy deposition kernel to form dose
 	int nSlice = Round<int>(m_vIsocenter_vxl[2]);
-	CString strSlice;
-	strSlice.Format(_T("Calc dose for slice %i\n"), nSlice);
-	TRACE(strSlice);
-	// ::AfxMessageBox(strSlice);
+	RTM_TRACE("Calc dose for slice %i\n", nSlice);
 	m_pEnergy = m_pKernel->CalcSphereConvolve(m_densityRep, m_pTerma, Round<int>(m_vIsocenter_vxl[2]));
 
 #ifdef USE_2D

--- a/RtModel/ConjGradOptimizer.cpp
+++ b/RtModel/ConjGradOptimizer.cpp
@@ -137,7 +137,7 @@ vnl_nonlinear_minimizer::ReturnCodes
 	// if we are too short,
 	if (m_vGrad.magnitude() < 1e-8)
 	{
-		Log(_T("Gradient too small -- adding length"));
+		Log("Gradient too small -- adding length");
 		// NOTE: must be a step large enough for the line minimizer's initial
 		//	bracket to produce a distinguishable function value -- get_x_tolerance()
 		//	is a convergence tolerance, not a usable step scale, and using it here
@@ -234,10 +234,8 @@ vnl_nonlinear_minimizer::ReturnCodes
 
 		const REAL gradNorm = m_vGrad.magnitude();		// |grad F| at the new point
 		{
-			CString __logMsg;
-			__logMsg.Format(_T("iter %d: F=%.6g |gradF|=%.6g"),
+			RTM_TRACE("iter %d: F=%.6g |gradF|=%.6g",
 				num_iterations_, (double) m_FinalValue, (double) gradNorm);
-			Log(__logMsg);
 		}
 
 		// choose the convergence criterion: gradient-norm if BRIMSTONE_GRAD_TOL
@@ -461,10 +459,9 @@ void
 		m_FreeEnergy = m_FinalValue - m_Entropy;
 
 		{
-			CString __logMsg;
-			__logMsg.Format(_T("Iteration %d: KL=%.6f, Entropy=%.6f, FreeEnergy=%.6f"),
-				num_iterations_, m_FinalValue, m_Entropy, m_FreeEnergy);
-			Log(__logMsg);
+			RTM_TRACE("Iteration %d: KL=%.6f, Entropy=%.6f, FreeEnergy=%.6f",
+				(int) num_iterations_, (double) m_FinalValue,
+				(double) m_Entropy, (double) m_FreeEnergy);
 		}
 	}
 

--- a/RtModel/EnergyDepKernel.cpp
+++ b/RtModel/EnergyDepKernel.cpp
@@ -222,15 +222,14 @@ void
 //////////////////////////////////////////////////////////////////////
 void CEnergyDepKernel::LoadKernel()
 {
-	CString strFilename;
-
 	// form current path
-	HMODULE hCurrModule = ::GetModuleHandle(NULL);
-	::GetModuleFileName(hCurrModule, strFilename.GetBuffer(255), 255);
-	strFilename.ReleaseBuffer();
+	char szModulePath[MAX_PATH] = "";
+	::GetModuleFileNameA(::GetModuleHandle(NULL), szModulePath, MAX_PATH);
 
-	int nLastSlash = strFilename.ReverseFind('\\');
-	strFilename = strFilename.Left(nLastSlash);
+	std::string strFilename(szModulePath);
+	std::string::size_type nLastSlash = strFilename.find_last_of('\\');
+	if (nLastSlash != std::string::npos)
+		strFilename = strFilename.substr(0, nLastSlash);
 
 	if (IsApproxEqual(m_energy, 15.0))
 	{
@@ -250,15 +249,16 @@ void CEnergyDepKernel::LoadKernel()
 	}
 	else
 	{
-		ASSERT(FALSE);
+		assert(false);
 	}
 
 	// The dose spread arrays produced by SUM_ELEMENT.FOR are read.
 	FILE *pFile = NULL;
-	_tfopen_s(&pFile, strFilename, _T("rt"));
+	fopen_s(&pFile, strFilename.c_str(), "rt");
 	if (pFile == NULL)
 	{
-		::AfxMessageBox(_T("Problem reading kernel..."));
+		// NOTE: was ::AfxMessageBox -- a library must not raise UI
+		RTM_TRACE("Problem reading kernel: %s\n", strFilename.c_str());
 		return;
 	}
 

--- a/RtModel/Histogram.cpp
+++ b/RtModel/Histogram.cpp
@@ -125,7 +125,7 @@ void
 	// sets up the binning parameters
 {
 	// only tested with this condition
-	ASSERT(sigma_mult == GBINS_BUFFER);
+	assert(sigma_mult == GBINS_BUFFER);
 
 	m_minValue = min_value - sigma_mult * sqrt(m_varMax); // m_binKernelSigma;
 	m_binWidth = width;
@@ -195,7 +195,7 @@ void
 #ifdef _DEBUG
 	double sum = 0.0;
 	ITERATE_VECTOR(m_binKernelVarMax, nAt, sum += m_binKernelVarMax[nAt]);
-	ASSERT(IsApproxEqual(sum, 1.0));
+	assert(IsApproxEqual(sum, 1.0));
 #endif
 
 	m_bin_dKernelVarMax.SetDim(nNeighborhood * 2 + 1);
@@ -595,7 +595,7 @@ const CVectorN<>&
 				}
 
 				// check that region is positive definite
-				ASSERT(GetRegion()->GetBufferPointer()[nAt] >= 0.0);
+				assert(GetRegion()->GetBufferPointer()[nAt] >= 0.0);
 
 				m_arrBinsVarMax[nLowBin] += m_volBinFracLo_x_VarFracHi->GetBufferPointer()[nAt];
 				m_arrBinsVarMin[nLowBin] += m_volBinFracLo_x_VarFracLo->GetBufferPointer()[nAt];
@@ -616,7 +616,7 @@ const CVectorN<>&
 		{
 			ConvGauss(m_arrBinsVarMax, m_binKernelVarMax, m_arrGBinsVarMax);
 			ConvGauss(m_arrBinsVarMin, m_binKernelVarMin, m_arrGBinsVarMin);
-			ASSERT(m_arrGBinsVarMax.GetDim() == m_arrGBinsVarMin.GetDim());
+			assert(m_arrGBinsVarMax.GetDim() == m_arrGBinsVarMin.GetDim());
 
 			m_arrGBins.SetDim(m_arrGBinsVarMax.GetDim());
 			m_arrGBins = m_arrGBinsVarMax;
@@ -690,7 +690,7 @@ const CVectorN<>&
 	GetBins();
 	if (m_varMax == 0.0)
 	{
-		ASSERT(FALSE);
+		assert(false);
 		return m_arrBins;
 	}
 
@@ -718,16 +718,16 @@ void
 	CHistogram::ConvGauss(const CVectorN<>& buffer_in, const CVectorN<>& kernel_in,
 						   CVectorN<>& buffer_out) const
 {
-	BeginLogSection(_T("CHistogram::ConvGauss"));
+	BeginLogSection("CHistogram::ConvGauss");
 
-	TraceVector(_T("kernel_in"), kernel_in);
-	TraceVector(_T("buffer_in"), buffer_in);
+	TraceVector("kernel_in", kernel_in);
+	TraceVector("buffer_in", buffer_in);
 
 	buffer_out.SetDim(buffer_in.GetDim() + kernel_in.GetDim() - 1);
 	buffer_out.SetZero();
 
 	// make sure REAL is double
-	ASSERT(sizeof(REAL) == 8);
+	assert(sizeof(REAL) == 8);
 
 	{
 		// Manual 1-D linear convolution. ippsConv_64f short-form was removed in
@@ -735,7 +735,7 @@ void
 		const int srcLen = buffer_in.GetDim();
 		const int kerLen = kernel_in.GetDim();
 		const int dstLen = srcLen + kerLen - 1;
-		ASSERT(buffer_out.GetDim() == dstLen);
+		assert(buffer_out.GetDim() == dstLen);
 		for (int n = 0; n < dstLen; ++n)
 		{
 			double acc = 0.0;
@@ -747,7 +747,7 @@ void
 		}
 	}
 
-	TraceVector(_T("buffer_out"), buffer_out);
+	TraceVector("buffer_out", buffer_out);
 
 	EndLogSection();
 
@@ -778,15 +778,15 @@ void
 	m_bRecomputeBinScaledVolume = TRUE;
 
 	//int nGroups = GetGroupCount();
-	for (int nAt = 0; nAt < m_arr_bRecomputeBinVolume.GetSize(); nAt++)
+	for (int nAt = 0; nAt < (int) m_arr_bRecomputeBinVolume.size(); nAt++)
 	{
-		m_arr_bRecomputeBinVolume[nAt] = TRUE;
+		m_arr_bRecomputeBinVolume[nAt] = true;
 	}
 
 	// set recalc flag for dBins
-	for (int nAt = 0; nAt < m_arr_bRecompute_dBins.GetSize(); nAt++)
+	for (int nAt = 0; nAt < (int) m_arr_bRecompute_dBins.size(); nAt++)
 	{
-		m_arr_bRecompute_dBins[nAt] = TRUE;
+		m_arr_bRecompute_dBins[nAt] = true;
 	}
 
 	// TODO: flag recompute dVolume_x_Region
@@ -802,9 +802,9 @@ void
 	CHistogram::OnRegionChanged() // CObservableEvent * pEvt, void * pParam)
 	// called when region updated
 {
-	for (int nAt = 0; nAt < m_arr_bRecompute_dVolumes_x_Region.GetSize(); nAt++)
+	for (int nAt = 0; nAt < (int) m_arr_bRecompute_dVolumes_x_Region.size(); nAt++)
 	{
-		m_arr_bRecompute_dVolumes_x_Region[nAt] = TRUE;
+		m_arr_bRecompute_dVolumes_x_Region[nAt] = true;
 	}
 
 	m_bRecomputeBins = TRUE;

--- a/RtModel/HistogramGradient.cpp
+++ b/RtModel/HistogramGradient.cpp
@@ -37,7 +37,7 @@ int CHistogramWithGradient::GetGroupCount() const
 	// returns the count of groups of dVolumes
 {
 	int nMaxGroup = -1;
-	for (int nAt = 0; nAt < m_arrVolumeGroups.GetSize(); nAt++)
+	for (int nAt = 0; nAt < (int) m_arrVolumeGroups.size(); nAt++)
 	{
 		nMaxGroup = __max(nMaxGroup, m_arrVolumeGroups[nAt]);
 	}
@@ -67,11 +67,11 @@ int
 {
 	m_arr_dVolumes.push_back(p_dVolume); 
 	int nNewVolumeIndex = (int) m_arr_dVolumes.size()-1; 
-	m_arrVolumeGroups.Add(nGroup);
+	m_arrVolumeGroups.push_back(nGroup);
 	while (m_groupVolBinLoInt.size() <= (size_t) nGroup)
 	{
 		m_groupVolBinLoInt.push_back(VolumeShort::New());
-		m_arr_bRecomputeBinVolume.Add(TRUE);
+		m_arr_bRecomputeBinVolume.push_back(true);
 
 		m_groupVolBinFracHi.push_back(VolumeReal::New());
 		m_groupVolBinFracLo.push_back(VolumeReal::New());
@@ -111,7 +111,7 @@ int
 	}
 
 	// set flag for computing bins for new dVolume
-	m_arr_bRecompute_dBins.Add(TRUE);
+	m_arr_bRecompute_dBins.push_back(true);
 
 	// add new product volume
 	VolumeReal::Pointer p_dVolume_x_Region = VolumeReal::New();
@@ -119,11 +119,11 @@ int
 	m_arr_dVolumes_x_Region.push_back(p_dVolume_x_Region); 
 
 	// add the derivative bins
-	m_arr_dBins.SetSize(Get_dVolumeCount());
-	m_arr_dGBins.SetSize(Get_dVolumeCount());
+	m_arr_dBins.resize(Get_dVolumeCount());
+	m_arr_dGBins.resize(Get_dVolumeCount());
 
 	// flag to recompute 
-	m_arr_bRecompute_dVolumes_x_Region.Add(TRUE);
+	m_arr_bRecompute_dVolumes_x_Region.push_back(true);
 
 	return nNewVolumeIndex;
 
@@ -212,7 +212,7 @@ const CVectorN<>&
 
 			Conv_dGauss(arr_dBins, m_bin_dKernelVarMax, arr_dGBinsVarMax);
 			Conv_dGauss(arr_dBins, m_bin_dKernelVarMin, arr_dGBinsVarMin);
-			ASSERT(arr_dGBinsVarMax.GetDim() == arr_dGBinsVarMin.GetDim());
+			assert(arr_dGBinsVarMax.GetDim() == arr_dGBinsVarMin.GetDim());
 
 
 			// determine variance using dSigmoid
@@ -273,7 +273,7 @@ const CVectorN<>&
 				m_arr_dGBins[nAt_dBin] *= R(1.0 / ((double) calcSum));
 			}
 		}
-		m_arr_bRecompute_dBins[nAt_dBin] = FALSE;
+		m_arr_bRecompute_dBins[nAt_dBin] = false;
 	}
 
 	return m_arr_dBins[nAt_dBin];
@@ -288,7 +288,7 @@ const CVectorN<>&
 {
 	if (m_varMax == 0.0)
 	{
-		ASSERT(FALSE);	// not OK, because we need to normalize
+		assert(false);	// not OK, because we need to normalize
 		return Get_dBins(nAt);
 	}
 
@@ -332,7 +332,7 @@ const VolumeReal *
 		//		MakeIppiSize<3>(m_arr_dVolumes_x_Region[nAt]->GetBufferedRegion())) ); 
 		//}
 
-		m_arr_bRecompute_dVolumes_x_Region[nAt] = FALSE;
+		m_arr_bRecompute_dVolumes_x_Region[nAt] = false;
 	}
 
 	return m_arr_dVolumes_x_Region[nAt];
@@ -531,7 +531,7 @@ const VolumeShort *
 		//}
 
 		// flag change
-		m_arr_bRecomputeBinVolume[nGroup] = TRUE;
+		m_arr_bRecomputeBinVolume[nGroup] = true;
 	}
 
 	return m_groupVolBinLoInt[nGroup];
@@ -555,7 +555,7 @@ void CHistogramWithGradient::Conv_dGauss(const CVectorN<>& buffer_in,
 		const int srcLen = buffer_in.GetDim();
 		const int kerLen = kernel_in.GetDim();
 		const int dstLen = srcLen + kerLen - 1;
-		ASSERT(buffer_out.GetDim() == dstLen);
+		assert(buffer_out.GetDim() == dstLen);
 		for (int n = 0; n < dstLen; ++n)
 		{
 			double acc = 0.0;

--- a/RtModel/KLDivTerm.cpp
+++ b/RtModel/KLDivTerm.cpp
@@ -24,13 +24,11 @@ KLDivTerm::KLDivTerm(Structure *pStructure, REAL weight)
 	SetInterval(0.0, 0.01, 1.0, FALSE);
 
 	// initialize flag
-	int nTargetCrossEntropy = 
-		::AfxGetApp()->GetProfileInt(_T("KLDivTerm"), _T("TargetCrossEntropy"), 0);
+	int nTargetCrossEntropy =
+		GetProfileInt("KLDivTerm", "TargetCrossEntropy", 0);
 	m_bTargetCrossEntropy = (nTargetCrossEntropy != 0);
 
-	// store value back to registry
-	::AfxGetApp()->WriteProfileInt(_T("KLDivTerm"), _T("TargetCrossEntropy"), nTargetCrossEntropy);
-		
+
 	// set up to receive binning change events
 	//GetHistogram()->GetBinningChangeEvent().AddObserver(this, 
 	//	(ListenerFunction) &KLDivTerm::OnHistogramBinningChange);
@@ -48,7 +46,7 @@ void
 	KLDivTerm::UpdateFrom(const VOITerm *otherTerm)
 {
 	VOITerm::UpdateFrom(otherTerm);
-	ASSERT(otherTerm->GetVOI() == this->GetVOI());
+	assert(otherTerm->GetVOI() == this->GetVOI());
 
 	const KLDivTerm * otherKLDT = static_cast<const KLDivTerm *>(otherTerm);
 	SetDVPs(otherKLDT->GetDVPs());
@@ -77,8 +75,8 @@ void
 	m_mDVPs = mDVPs;
 
 	// check that cumulative DVPs start at 100%
-	ASSERT(IsApproxEqual(m_mDVPs[0][1], R(1.0)));
-	ASSERT(IsApproxEqual(m_mDVPs[mDVPs.GetCols()-1][1], R(0.0)));
+	assert(IsApproxEqual(m_mDVPs[0][1], R(1.0)));
+	assert(IsApproxEqual(m_mDVPs[mDVPs.GetCols()-1][1], R(0.0)));
 
 	// trigger recomp of target bins
 	m_bRecompTarget = true;
@@ -216,7 +214,7 @@ const CVectorN<>&
 
 ///////////////////////////////////////////////////////////////////////////////
 REAL 
-	KLDivTerm::Eval(CVectorN<> *pvGrad, const CArray<BOOL, BOOL>& arrInclude)
+	KLDivTerm::Eval(CVectorN<> *pvGrad, const std::vector<BOOL>& arrInclude)
 	// evaluates the term (and optionally gradient)
 {
 	// trigger update of targets
@@ -236,13 +234,13 @@ REAL
 		{
 			if (nAtBin < targetGPDF.GetDim())
 			{
-				// ASSERT(targetGPDF[nAtBin] >= 0.0);
+				// assert(targetGPDF[nAtBin] >= 0.0);
 				sum += calcGPDF[nAtBin] * log(calcGPDF[nAtBin] / (targetGPDF[nAtBin] + EPS) + EPS);
 			}
 			else
 			{
 				sum += calcGPDF[nAtBin] * log(calcGPDF[nAtBin] / (EPS) + EPS);	
-				ASSERT(_finite(sum));
+				assert(_finite(sum));
 			}
 		}
 	}
@@ -358,7 +356,7 @@ REAL
 			// get the dGPDF distribution
 			const CVectorN<>& arrCalc_dGPDF = GetHistogram()->Get_dGBins(nAt_dVol);
 
-			ASSERT(arrCalc_dGPDF.GetDim() >= calcGPDF.GetDim());
+			assert(arrCalc_dGPDF.GetDim() >= calcGPDF.GetDim());
 			if (!m_bTargetCrossEntropy)
 			{
 				for (int nAtBin = 0; nAtBin < __max(targetGPDF.GetDim(), arrCalc_dGPDF.GetDim()); nAtBin++)

--- a/RtModel/ObjectiveFunction.cpp
+++ b/RtModel/ObjectiveFunction.cpp
@@ -64,7 +64,7 @@ void
 void DynamicCovarianceCostFunction::Transform(CVectorN<> *pvInOut) const
 {
 	// default is identity transform
-	ASSERT(false);
+	assert(false);
 
 }	// CObjectiveFunction::Transform
 
@@ -88,7 +88,7 @@ void DynamicCovarianceCostFunction::dTransform(CVectorN<> *pvInOut) const
 void DynamicCovarianceCostFunction::InvTransform(CVectorN<> *pvInOut) const
 {
 	// default is identity transform
-	ASSERT(false);
+	assert(false);
 
 }	// CObjectiveFunction::InvTransform
 

--- a/RtModel/Plan.cpp
+++ b/RtModel/Plan.cpp
@@ -30,14 +30,9 @@ Plan::Plan()
 Plan::~Plan()
 {
 	// delete the histograms
-	POSITION pos = m_mapHistograms.GetStartPosition();
-	while (NULL != pos)
+	for (auto& entry : m_mapHistograms)
 	{
-		CString strName;
-		CHistogram *pHistogram = NULL;
-		m_mapHistograms.GetNextAssoc(pos, strName, pHistogram); 
-
-		delete pHistogram;
+		delete entry.second;
 	}
 
 	// delete the kernel
@@ -155,13 +150,9 @@ void
 	GetDoseMatrix();
 
 	// now iterate over histo's
-	POSITION pos = m_mapHistograms.GetStartPosition();
-	CString strName;
-	CHistogram *pHisto;
-	while (pos != NULL)
+	for (auto& entry : m_mapHistograms)
 	{
-		m_mapHistograms.GetNextAssoc(pos, strName, pHisto);
-		pHisto->OnVolumeChange(); // NULL, NULL);
+		entry.second->OnVolumeChange(); // NULL, NULL);
 	}
 #endif
 }
@@ -207,7 +198,12 @@ CHistogram *
 {
 	CHistogram *pHisto = NULL;
 #ifdef USE_RTOPT
-	if (!m_mapHistograms.Lookup(CString(pStructure->GetName().c_str()), pHisto))
+	auto iterFound = m_mapHistograms.find(pStructure->GetName());
+	if (iterFound != m_mapHistograms.end())
+	{
+		pHisto = iterFound->second;
+	}
+	else
 	{
 		if (bCreate)
 		{
@@ -226,7 +222,7 @@ CHistogram *
 			pHisto->SetSlice(nSlice);
 
 			// add to map
-			m_mapHistograms[CString(pStructure->GetName().c_str())] = pHisto;
+			m_mapHistograms[pStructure->GetName()] = pHisto;
 		}
 	}
 
@@ -247,11 +243,11 @@ void
 	Plan::RemoveHistogram(dH::Structure *pStructure)
 {
 #ifdef USE_RTOPT
-	CHistogram *pHisto = NULL;
-	if (m_mapHistograms.Lookup(CString(pStructure->GetName().c_str()), pHisto))
+	auto iterFound = m_mapHistograms.find(pStructure->GetName());
+	if (iterFound != m_mapHistograms.end())
 	{
-		m_mapHistograms.RemoveKey(CString(pStructure->GetName().c_str()));
-		delete pHisto;
+		delete iterFound->second;
+		m_mapHistograms.erase(iterFound);
 	}
 #endif
 }

--- a/RtModel/PlanOptimizer.cpp
+++ b/RtModel/PlanOptimizer.cpp
@@ -11,32 +11,31 @@ namespace dH
 
 ///////////////////////////////////////////////////////////////////////////////
 
-// constants for access to the registry
-const CString REG_KEY			= _T("Prescription");
+// section name for settings access
+const char * const REG_KEY		= "Prescription";
 
 ///////////////////////////////////////////////////////////////////////////////
 /// TODO: move this to utils
-REAL 
-	GetProfileRealAt(const CString& strKey, int nAt, REAL defaultValue)
+REAL
+	GetProfileRealAt(const char *pszKey, int nAt, REAL defaultValue)
 {
-	USES_CONVERSION;
-	CString strKeyAt;
-	strKeyAt.Format(strKey, nAt);
-	return GetProfileReal(W2A(REG_KEY), W2A(strKeyAt), defaultValue);
+	char szKeyAt[128];
+	snprintf(szKeyAt, sizeof(szKeyAt), pszKey, nAt);
+	return GetProfileReal(REG_KEY, szKeyAt, defaultValue);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 
 // other constants + registry keys
 
-const CString GBINSIGMA_KEY		= _T("GBinSigma");
+const char * const GBINSIGMA_KEY	= "GBinSigma";
 const REAL DEFAULT_GBINSIGMA	= 0.2;
 
-const CString LEVELSIGMA_KEY	= _T("LevelSigma%i");
+const char * const LEVELSIGMA_KEY	= "LevelSigma%i";
 const REAL DEFAULT_LEVELSIGMA[] = {8.0, 3.2, 1.3, 0.5, 0.25}; // { 8.0, 4.0, 2.0, 1.0, 0.5 };
 
-const CString CGTOL_KEY			= _T("CGTolerance%i");
-const CString LINETOL_KEY		= _T("Tolerance%i");
+const char * const CGTOL_KEY		= "CGTolerance%i";
+const char * const LINETOL_KEY		= "Tolerance%i";
 
 // Per-level convergence tolerances, indexed by nLevel. IMPORTANT: level 0 is
 //	the FINEST resolution (0.5mm) and level MAX_SCALES-1 is the COARSEST (8mm)
@@ -226,11 +225,9 @@ bool
 			CVectorN<> dtDiag = vInit;
 			pPresc->dTransform(&dtDiag);
 			const REAL doseMax = GetMax<VOXEL_REAL>(pPresc->m_sumVolume);
-			CString __d;
-			__d.Format(_T("LEVELDIAG dim=%d F=%.6g KL=%.6g |gradF|=%.6g |dTransform|=%.6g doseMax=%.6g\n"),
+			RTM_TRACE("LEVELDIAG dim=%d F=%.6g KL=%.6g |gradF|=%.6g |dTransform|=%.6g doseMax=%.6g\n",
 				vInit.GetDim(), (double) fDiag, (double) pPresc->GetLastKL(),
 				(double) gDiag.GetLength(), (double) dtDiag.GetLength(), (double) doseMax);
-			OutputDebugString(__d);
 		}
 
 		// NOTE: this needs to be in the form of an initializer,
@@ -284,7 +281,7 @@ void
 		else
 		{
 			vInit[nAt] = R(0.001) / R(GetPlan()->GetBeamCount());
-			TRACE("Excluded element %n\n", nAt);
+			RTM_TRACE("Excluded element %d\n", nAt);
 		}
 	}
 
@@ -332,7 +329,7 @@ void
 	PlanOptimizer::InvFilterStateVector(int nScale, const CVectorN<>& vIn, CVectorN<>& vOut)
 	// transfers beamlet weights from level n-1 to level n
 {
-	ASSERT(&vIn != &vOut);
+	assert(&vIn != &vOut);
 	// TODO: make a member so don't have to re-initialize
 	//CMatrixNxM<> mBeamletWeights;
 	//StateVectorToBeamletWeights(nScale, vIn, mBeamletWeights);
@@ -380,13 +377,12 @@ void
 	PlanOptimizer::SetupPrescription()
 	// returns the given level of the pyramid
 {
-	USES_CONVERSION;
 
 	// create the pyramid
 	SetPyramid(new dH::PlanPyramid(GetPlan()));
 
 	// get main sigma parameter from registry
-	const REAL GBinSigma = GetProfileReal(W2A(REG_KEY), W2A(GBINSIGMA_KEY), DEFAULT_GBINSIGMA);
+	const REAL GBinSigma = GetProfileReal(REG_KEY, GBINSIGMA_KEY, DEFAULT_GBINSIGMA);
 
 	// form vector with levels of the presc object
 	m_arrPrescriptions.clear();
@@ -464,7 +460,7 @@ void
 	int nBeamletOffset = nBeamletCount / 2;
 	ConformTo<VOXEL_REAL>(pPlan->GetBeamAt(nBeam)->GetIntensityMap(), 
 		pIntensityMap);		// TODO: make this an ASSERT, as caller should be responsible for this
-	ASSERT(nBeamletCount == pIntensityMap->GetBufferedRegion().GetSize()[0]);
+	assert(nBeamletCount == pIntensityMap->GetBufferedRegion().GetSize()[0]);
 
 	for (int nAtElem = 0; nAtElem < vState.GetDim(); nAtElem++)
 	{

--- a/RtModel/PlanPyramid.cpp
+++ b/RtModel/PlanPyramid.cpp
@@ -81,7 +81,7 @@ void
 			pNextBeam->SetIsocenter(pPrevBeam->GetIsocenter());
 
 		}
-		ASSERT(pPrevPlan->GetBeamCount() == pNextPlan->GetBeamCount());
+		assert(pPrevPlan->GetBeamCount() == pNextPlan->GetBeamCount());
 
 		pPrevPlan = pNextPlan;
 	}
@@ -204,7 +204,7 @@ void
 				CopyImage<VOXEL_REAL,3>(pPyramid->GetOutput(0), pBeamSub->GetBeamlet(nAtShift));
 
 				// check that resolution is correct
-				ASSERT(pBeamSub->GetBeamlet(nAtShift)->GetSpacing()[0] == pBeamSub->GetPlan()->GetDoseResolution());
+				assert(pBeamSub->GetBeamlet(nAtShift)->GetSpacing()[0] == pBeamSub->GetPlan()->GetDoseResolution());
 			}
 		}
 
@@ -225,8 +225,8 @@ PlanPyramid::InvFiltIntensityMap(int nLevel, const CBeam::IntensityMap * vWeight
 	const int nWeightsSize = (int) vWeights->GetBufferedRegion().GetSize()[0];
 	const int nFiltWeightsSize = (int) vFiltWeights->GetBufferedRegion().GetSize()[0];
 
-	ASSERT(nWeightsSize == GetPlan(nLevel)->GetBeamAt(0)->GetBeamletCount());
-	ASSERT(nFiltWeightsSize == GetPlan(nLevel-1)->GetBeamAt(0)->GetBeamletCount());
+	assert(nWeightsSize == GetPlan(nLevel)->GetBeamAt(0)->GetBeamletCount());
+	assert(nFiltWeightsSize == GetPlan(nLevel-1)->GetBeamAt(0)->GetBeamletCount());
 
 	// the ASSERTs above are compiled out in release, where a size mismatch
 	//	silently overruns the buffers indexed below (the write extent comes

--- a/RtModel/Prescription.cpp
+++ b/RtModel/Prescription.cpp
@@ -84,13 +84,9 @@ bool
 ///////////////////////////////////////////////////////////////////////////////
 Prescription::~Prescription()
 {
-	dH::Structure *pStruct = NULL;
-	VOITerm *pVOIT = NULL;
-	POSITION pos = m_mapVOITs.GetStartPosition();
-	while (pos != NULL)
+	for (auto& entry : m_mapVOITs)
 	{
-		m_mapVOITs.GetNextAssoc(pos, pStruct, pVOIT);
-		delete pVOIT;
+		delete entry.second;
 	}
 
 }	// Prescription::~Prescription
@@ -99,10 +95,9 @@ Prescription::~Prescription()
 VOITerm *
 	Prescription::GetStructureTerm(Structure *pStruct)
 {
-	VOITerm *pVOIT = NULL;
-	m_mapVOITs.Lookup(pStruct, pVOIT);
+	auto iter = m_mapVOITs.find(pStruct);
 
-	return pVOIT;
+	return (iter != m_mapVOITs.end()) ? iter->second : NULL;
 
 }	// Prescription::GetStructureTerm
 
@@ -171,7 +166,7 @@ void
 			nOtherSlice++)
 		{
 			sliceMax = GetSliceMax(pResampRegion, nOtherSlice);
-			TRACE("sliceMax on slice %i = %lf\n", nOtherSlice, sliceMax);
+			RTM_TRACE("sliceMax on slice %i = %lf\n", nOtherSlice, sliceMax);
 		}
 	}
 
@@ -203,11 +198,11 @@ void
 void 
 	Prescription::RemoveStructureTerm(Structure *pStruct)
 {
-	VOITerm *pVOIT = NULL;
-	if (m_mapVOITs.Lookup(pStruct, pVOIT))
+	auto iter = m_mapVOITs.find(pStruct);
+	if (iter != m_mapVOITs.end())
 	{
-		m_mapVOITs.RemoveKey(pStruct);
-		delete pVOIT;
+		delete iter->second;
+		m_mapVOITs.erase(iter);
 	}
 
 }	// Prescription::RemoveStructureTerm
@@ -218,19 +213,13 @@ void
 	// updates terms from another prescription object
 {
 	// now for the terms
-	POSITION pos = pPresc->m_mapVOITs.GetStartPosition();
-	while (pos != NULL)
+	for (auto& entry : pPresc->m_mapVOITs)
 	{
-		Structure * pStruct = NULL;
-		VOITerm *pVOIT = NULL;
-		pPresc->m_mapVOITs.GetNextAssoc(pos, pStruct, pVOIT);
-
-		VOITerm *pMyVOIT = NULL;
-		BOOL bFound = m_mapVOITs.Lookup(pStruct, pMyVOIT);
-		ASSERT(bFound);
+		auto iterMine = m_mapVOITs.find(entry.first);
+		assert(iterMine != m_mapVOITs.end());
 
 		// assignment operator -- copies all relevent fields
-		pMyVOIT->UpdateFrom(pVOIT);
+		iterMine->second->UpdateFrom(entry.second);
 	}
 
 }	// Prescription::UpdateTerms
@@ -245,7 +234,7 @@ void
 
 	// varMax *= 1.5; // 2.0;
 	// if (!IsApproxEqual(m_varMax, varMax))
-	//	::AfxMessageBox(_T("Problem!!!"));
+	//	::AfxMessageBox("Problem!!!");
 	m_varMax = varMax;
 	if (GetTransformSlopeVariance())
 	{
@@ -261,14 +250,9 @@ void
 	}
 
 	// now set up the histogram variances
-	POSITION pos = m_mapVOITs.GetStartPosition();
-	while (pos != NULL)
+	for (auto& entry : m_mapVOITs)
 	{
-		Structure *pStruct = NULL;
-		VOITerm *pVOIT = NULL;
-		m_mapVOITs.GetNextAssoc(pos, pStruct, pVOIT);
-
-		pVOIT->GetHistogram()->SetGBinVar(&m_ActualAV/*m_pAV*/, m_varMin, m_varMax);
+		entry.second->GetHistogram()->SetGBinVar(&m_ActualAV/*m_pAV*/, m_varMin, m_varMax);
 	}
 
 }	// Prescription::SetGBinVar
@@ -278,19 +262,18 @@ REAL
 	Prescription::operator()(const CVectorN<>& vInput, CVectorN<> *pGrad ) const
 	// objective function evaluator
 {
-	USES_CONVERSION;
 
 	// initialize total sum of objective function
 	REAL totalSum = 0.0;
 
-	BeginLogSection(_T("Prescription::operator()"));
+	BeginLogSection("Prescription::operator()");
 
-	TraceVector(_T("vInput"), vInput);
+	TraceVector("vInput", vInput);
 
 	// transform input for calc purposes
 	CVectorN<> vInputTrans = vInput;
 	Transform(&vInputTrans);
-	TraceVector(_T("vInputTrans"), vInputTrans);
+	TraceVector("vInputTrans", vInputTrans);
 
 	// dTransform of the input -- flag is used to only calculate it if needed (if there is a gradient)
 	CVectorN<> v_dInputTrans;
@@ -306,19 +289,16 @@ REAL
 		v_dInputTrans.SetDim(vInput.GetDim());
 		v_dInputTrans = vInput;
 		dTransform(&v_dInputTrans);
-		TraceVector(_T("v_dInputTrans"), v_dInputTrans);
+		TraceVector("v_dInputTrans", v_dInputTrans);
 	}
 
 	// flag to indicate need to call CalcSumSigmoid
 	bool bCalcSum = true;
 
 	// iterate over the VOITerms
-	POSITION pos = m_mapVOITs.GetStartPosition();
-	while (pos != NULL)
+	for (const auto& entry : m_mapVOITs)
 	{
-		Structure *pStruct = NULL;
-		VOITerm *pVOIT = NULL;
-		m_mapVOITs.GetNextAssoc(pos, pStruct, pVOIT);
+		VOITerm *pVOIT = entry.second;
 
 		// calculate the summed volume, if this is the first VOIT
 		if (bCalcSum)
@@ -329,10 +309,8 @@ REAL
 
 		if (pVOIT->GetWeight() >= DEFAULT_EPSILON)
 		{
-			CString strMessage;
-			strMessage.Format(_T("VOI = %s\n"), 
-				A2W(pVOIT->GetVOI()->GetName().c_str()));
-			OutputDebugString(strMessage);
+			RTM_TRACE("VOI = %s\n",
+				pVOIT->GetVOI()->GetName().c_str());
 
 			// set fractions to histo
 			pVOIT->GetHistogram()->SetVarFracVolumes(m_volMainMinVar, m_volMainMaxVar);
@@ -359,7 +337,7 @@ REAL
 					m_vPartGrad[nAt] *= v_dInputTrans[nAt]; 
 				}
 
-				TraceVector(_T("m_vPartGrad"), m_vPartGrad);
+				TraceVector("m_vPartGrad", m_vPartGrad);
 
 				// add the partial gradient to the total
 				(*pGrad) += m_vPartGrad;
@@ -372,7 +350,7 @@ REAL
 	}
 
 	// good to catch an NANs
-	ASSERT(_finite(totalSum));
+	assert(_finite(totalSum));
 
 	// NOTE: previously added a fixed +0.1 offset here ("to hold it up off 0.0"),
 	//	but that constant leaked into the CG optimizer's relative convergence test
@@ -463,7 +441,7 @@ REAL
 		totalSum -= w * entropy;
 		m_dLastEntropy = entropy;
 
-		ASSERT(_finite(totalSum));
+		assert(_finite(totalSum));
 	}
 
 	EndLogSection();
@@ -478,10 +456,10 @@ void
 	Prescription::CalcSumSigmoid(CHistogramWithGradient *pHisto, 
 								   const CVectorN<>& vInput,
 								   const CVectorN<>& vInputTrans, 
-								   const CArray<BOOL, BOOL>& arrInclude) const
+								   const std::vector<BOOL>& arrInclude) const
 	// computes the sum of weights from an input vector
 {
-	BeginLogSection(_T("Prescription::CalcSumSigmoid"));
+	BeginLogSection("Prescription::CalcSumSigmoid");
 
 	// get the main volume
 	VolumeReal *pVolume = pHisto->GetVolume();
@@ -494,7 +472,7 @@ void
 	m_volMainMaxVar->FillBuffer(0.0);
 
 	// iterate over the component volumes, accumulating the weighted volumes
-	ASSERT(vInputTrans.GetDim() == pHisto->Get_dVolumeCount());
+	assert(vInputTrans.GetDim() == pHisto->Get_dVolumeCount());
 
 	int nMaxGroup = pHisto->GetGroupCount();
 	for (int nAtGroup = 0; nAtGroup < nMaxGroup; nAtGroup++)
@@ -531,8 +509,8 @@ void
 					}
 
 					// check adaptive variance value
-					ASSERT((*m_pAV)[nAt_dVolume] <= (m_varMax + 1e-6));
-					ASSERT((*m_pAV)[nAt_dVolume] >= (m_varMin - 1e-6));
+					assert((*m_pAV)[nAt_dVolume] <= (m_varMax + 1e-6));
+					assert((*m_pAV)[nAt_dVolume] >= (m_varMin - 1e-6));
 
 					// determine variance using dSigmoid
 					REAL varSlope = 1.0;
@@ -721,11 +699,9 @@ void
 	// helper to update the histogram regions
 {
 	// set up the histogram regions
-	for (POSITION pos = m_mapVOITs.GetStartPosition(); pos != NULL;)
+	for (auto& entry : m_mapVOITs)
 	{
-		Structure *pStruct = NULL;
-		VOITerm *pVOIT = NULL;
-		m_mapVOITs.GetNextAssoc(pos, pStruct, pVOIT);
+		VOITerm *pVOIT = entry.second;
 
 		// now reset the conform regions for the VOIT
 		VolumeReal *pResampRegion = pVOIT->GetVOI()->GetConformRegion(m_sumVolume);
@@ -746,20 +722,17 @@ void
 	// determines array of flags of beamlets (elements) to include in optimization
 {
 	// iterate over terms to find target term
-	POSITION pos = m_mapVOITs.GetStartPosition();
-	while (pos != NULL)
+	for (auto& entry : m_mapVOITs)
 	{
-		Structure *pStruct = NULL;
-		VOITerm *pVOIT = NULL;
-		m_mapVOITs.GetNextAssoc(pos, pStruct, pVOIT);
+		VOITerm *pVOIT = entry.second;
 
 		CHistogramWithGradient *pHisto = pVOIT->GetHistogram();
 
-		if (m_arrIncludeElement.GetSize() < pHisto->Get_dVolumeCount())
+		if ((int) m_arrIncludeElement.size() < pHisto->Get_dVolumeCount())
 		{
-			m_arrIncludeElement.SetSize(pHisto->Get_dVolumeCount());
+			m_arrIncludeElement.resize(pHisto->Get_dVolumeCount());
 
-			for (int nAt = 0; nAt < m_arrIncludeElement.GetSize(); nAt++)
+			for (int nAt = 0; nAt < (int) m_arrIncludeElement.size(); nAt++)
 			{
 				m_arrIncludeElement[nAt] = true;
 			}

--- a/RtModel/RtModel.vcxproj
+++ b/RtModel/RtModel.vcxproj
@@ -17,6 +17,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{7C848FBB-2C50-4F47-81C9-B872E9B504C1}</ProjectGuid>
@@ -26,30 +34,48 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <UseIntelIPP1A>Static_Library</UseIntelIPP1A>
+  </PropertyGroup>
+  <!-- ARM64: native build. No Intel IPP (x86-only), so USE_IPP is left undefined and
+       VectorOps.h falls back to its generic template implementations. VCToolsVersion is
+       pinned because MFC/ATL ships only with 14.51 here, not the default 14.52. -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v145</PlatformToolset>
+    <VCToolsVersion>14.51.36231</VCToolsVersion>
+    <UseOfMfc>Dynamic</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v145</PlatformToolset>
+    <VCToolsVersion>14.51.36231</VCToolsVersion>
+    <UseOfMfc>Dynamic</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -64,6 +90,12 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -83,6 +115,14 @@
     <IntDir>$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
@@ -209,6 +249,46 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>
+        .\include;
+        C:\vcpkg\installed\arm64-windows\include\ITK-5.4;
+        C:\vcpkg\installed\arm64-windows\include\vxl\core;
+        C:\vcpkg\installed\arm64-windows\include\vxl\vcl;
+        C:\vcpkg\installed\arm64-windows\include;
+        C:\vcpkg\installed\arm64-windows\include\eigen3;
+        %(AdditionalIncludeDirectories)
+      </AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;USE_RTOPT;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>
+        .\include;
+        C:\vcpkg\installed\arm64-windows\include\ITK-5.4;
+        C:\vcpkg\installed\arm64-windows\include\vxl\core;
+        C:\vcpkg\installed\arm64-windows\include\vxl\vcl;
+        C:\vcpkg\installed\arm64-windows\include;
+        C:\vcpkg\installed\arm64-windows\include\eigen3;
+        %(AdditionalIncludeDirectories)
+      </AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;USE_RTOPT;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Beam.cpp" />
     <ClCompile Include="BeamDoseCalc.cpp" />
@@ -230,6 +310,8 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="Structure.cpp" />
     <ClCompile Include="VOITerm.cpp" />

--- a/RtModel/Series.cpp
+++ b/RtModel/Series.cpp
@@ -12,7 +12,7 @@ namespace dH
 ///////////////////////////////////////////////////////////////////////////////
 Series::Series()
 {
-	BeginLogSection(_T("Series::Series"));
+	BeginLogSection("Series::Series");
 
 	SetDensity(VolumeReal::New());
 
@@ -67,15 +67,12 @@ Structure *
 void 
 	Series::AddStructure(Structure *pStruct)
 {
-	USES_CONVERSION;
-
-	BeginLogSection(_T("Series::AddStructure"));
+	BeginLogSection("Series::AddStructure");
 
 	// output the structure name
-	__formatMessage.Format(_T("<structure name=\"%s\" contours=\"%s\" />"), 
-		A2W(pStruct->GetName().c_str()),
+	RTM_TRACE("<structure name=\"%s\" contours=\"%d\" />",
+		pStruct->GetName().c_str(),
 		pStruct->GetContourCount());
-	Log(__formatMessage.GetBuffer());
 
 	pStruct->SetSeries(this);
 	m_arrStructures.push_back(pStruct);

--- a/RtModel/SigmaEstimator.cpp
+++ b/RtModel/SigmaEstimator.cpp
@@ -94,11 +94,9 @@ std::vector<REAL> SigmaEstimator::EstimatePyramidSigmas(
 	VolumeReal* pDose = pPlan->GetDoseMatrix();
 
 	// Iterate through all VOI terms
-	POSITION pos = pPresc->m_mapVOITs.GetStartPosition();
-	while (pos != NULL) {
-		Structure* pStruct = NULL;
-		VOITerm* pVOIT = NULL;
-		pPresc->m_mapVOITs.GetNextAssoc(pos, pStruct, pVOIT);
+	for (auto& entry : pPresc->m_mapVOITs) {
+		Structure* pStruct = entry.first;
+		VOITerm* pVOIT = entry.second;
 
 		if (pStruct && pVOIT) {
 			// Estimate sigma for this structure

--- a/RtModel/SigmaEstimator_Integration_Example.cpp
+++ b/RtModel/SigmaEstimator_Integration_Example.cpp
@@ -74,7 +74,7 @@ void PlanOptimizer_Example_SetupPrescription_WithAdaptiveSigma(
 		pPresc->SetGBinVar(varMin, varMax);
 
 		// Log the estimated sigma
-		TRACE("Level %d: Adaptive Sigma = %.3f (was %.3f)\n",
+		RTM_TRACE("Level %d: Adaptive Sigma = %.3f (was %.3f)\n",
 			nLevel,
 			sigma,
 			DEFAULT_LEVELSIGMA[nLevel]);
@@ -91,11 +91,9 @@ void Example_PerStructureSigmaEstimation(CPlan* pPlan, Prescription* pPresc)
 	VolumeReal* pDose = pPlan->GetDoseMatrix();
 
 	// Iterate through all VOI terms
-	POSITION pos = pPresc->m_mapVOITs.GetStartPosition();
-	while (pos != NULL) {
-		Structure* pStruct = NULL;
-		VOITerm* pVOIT = NULL;
-		pPresc->m_mapVOITs.GetNextAssoc(pos, pStruct, pVOIT);
+	for (auto& entry : pPresc->m_mapVOITs) {
+		Structure* pStruct = entry.first;
+		VOITerm* pVOIT = entry.second;
 
 		if (pStruct && pVOIT) {
 			// Estimate optimal sigma for this specific structure
@@ -105,7 +103,7 @@ void Example_PerStructureSigmaEstimation(CPlan* pPlan, Prescription* pPresc)
 				pVOIT);
 
 			// Log structure-specific recommendations
-			TRACE("Structure: %s, Recommended base sigma: %.3f\n",
+			RTM_TRACE("Structure: %s, Recommended base sigma: %.3f\n",
 				pStruct->GetName().c_str(),
 				structSigma);
 
@@ -152,7 +150,7 @@ public:
 		// If sigma changed significantly, update prescription
 		if (fabs(adaptedSigma - currentSigma) > 0.01) {
 			UpdatePrescriptionSigma(adaptedSigma);
-			TRACE("Level %d, Iter %d: Adapted sigma %.3f -> %.3f\n",
+			RTM_TRACE("Level %d, Iter %d: Adapted sigma %.3f -> %.3f\n",
 				m_level, m_iteration, currentSigma, adaptedSigma);
 		}
 
@@ -202,22 +200,22 @@ void Example_CompareDefaultVsAdaptive(CPlan* pPlan, Prescription* pPresc)
 		PlanPyramid::MAX_SCALES);
 
 	// Print comparison
-	TRACE("\n===== Sigma Comparison =====\n");
-	TRACE("Level | Default | Adaptive | Difference\n");
-	TRACE("------|---------|----------|------------\n");
+	RTM_TRACE("\n===== Sigma Comparison =====\n");
+	RTM_TRACE("Level | Default | Adaptive | Difference\n");
+	RTM_TRACE("------|---------|----------|------------\n");
 
 	for (int i = 0; i < PlanPyramid::MAX_SCALES; i++) {
 		REAL diff = adaptiveSigmas[i] - DEFAULT_LEVELSIGMA[i];
 		REAL pctDiff = 100.0 * diff / DEFAULT_LEVELSIGMA[i];
 
-		TRACE("  %d   |  %.3f  |  %.3f   | %+.3f (%+.1f%%)\n",
+		RTM_TRACE("  %d   |  %.3f  |  %.3f   | %+.3f (%+.1f%%)\n",
 			i,
 			DEFAULT_LEVELSIGMA[i],
 			adaptiveSigmas[i],
 			diff,
 			pctDiff);
 	}
-	TRACE("============================\n\n");
+	RTM_TRACE("============================\n\n");
 
 	// Could run optimization twice and compare results:
 	// 1. With DEFAULT_LEVELSIGMA
@@ -232,7 +230,7 @@ void Example_CompareDefaultVsAdaptive(CPlan* pPlan, Prescription* pPresc)
 void Example_RegistryControlledAdaptiveSigma(CPlan* pPlan, Prescription* pPresc)
 {
 	// Check registry key to enable/disable adaptive sigma
-	const CString ADAPTIVE_SIGMA_KEY = _T("UseAdaptiveSigma");
+	const std::string ADAPTIVE_SIGMA_KEY = "UseAdaptiveSigma";
 	BOOL bUseAdaptive = FALSE;
 
 	// Read from registry (would use GetProfileInt or similar)
@@ -248,14 +246,14 @@ void Example_RegistryControlledAdaptiveSigma(CPlan* pPlan, Prescription* pPresc)
 			pPresc,
 			PlanPyramid::MAX_SCALES);
 
-		TRACE("Using adaptive sigma estimation\n");
+		RTM_TRACE("Using adaptive sigma estimation\n");
 	} else {
 		// Use default hard-coded values
 		const REAL DEFAULT_LEVELSIGMA[] = {8.0, 3.2, 1.3, 0.5, 0.25};
 		sigmas.assign(DEFAULT_LEVELSIGMA,
 		              DEFAULT_LEVELSIGMA + PlanPyramid::MAX_SCALES);
 
-		TRACE("Using default sigma values\n");
+		RTM_TRACE("Using default sigma values\n");
 	}
 
 	// Continue with prescription setup using chosen sigmas...
@@ -270,49 +268,47 @@ void Example_DetailedSigmaAnalysis(CPlan* pPlan, Prescription* pPresc)
 	SigmaEstimator sigmaEst;
 	VolumeReal* pDose = pPlan->GetDoseMatrix();
 
-	TRACE("\n===== Structure-Based Sigma Analysis =====\n");
+	RTM_TRACE("\n===== Structure-Based Sigma Analysis =====\n");
 
 	// Analyze each structure
-	POSITION pos = pPresc->m_mapVOITs.GetStartPosition();
-	while (pos != NULL) {
-		Structure* pStruct = NULL;
-		VOITerm* pVOIT = NULL;
-		pPresc->m_mapVOITs.GetNextAssoc(pos, pStruct, pVOIT);
+	for (auto& entry : pPresc->m_mapVOITs) {
+		Structure* pStruct = entry.first;
+		VOITerm* pVOIT = entry.second;
 
 		if (pStruct) {
-			TRACE("\nStructure: %s\n", pStruct->GetName().c_str());
+			RTM_TRACE("\nStructure: %s\n", pStruct->GetName().c_str());
 
 			// Individual estimates
 			REAL geomSigma = sigmaEst.EstimateFromGeometry(pStruct);
-			TRACE("  Geometry-based sigma: %.3f\n", geomSigma);
+			RTM_TRACE("  Geometry-based sigma: %.3f\n", geomSigma);
 
 			if (pDose) {
 				REAL gradSigma = sigmaEst.EstimateFromDoseGradient(pStruct, pDose);
-				TRACE("  Dose gradient sigma: %.3f\n", gradSigma);
+				RTM_TRACE("  Dose gradient sigma: %.3f\n", gradSigma);
 			}
 
 			if (pVOIT) {
 				REAL prescSigma = sigmaEst.EstimateFromPrescriptionRange(pVOIT);
-				TRACE("  Prescription sigma: %.3f\n", prescSigma);
+				RTM_TRACE("  Prescription sigma: %.3f\n", prescSigma);
 			}
 
 			REAL volSigma = sigmaEst.EstimateFromVolume(pStruct);
-			TRACE("  Volume-based sigma: %.3f\n", volSigma);
+			RTM_TRACE("  Volume-based sigma: %.3f\n", volSigma);
 
 			// Combined estimate
 			REAL combinedSigma = sigmaEst.EstimateStructureSigma(
 				pStruct, pDose, pVOIT);
-			TRACE("  Combined estimate: %.3f\n", combinedSigma);
+			RTM_TRACE("  Combined estimate: %.3f\n", combinedSigma);
 
 			// Additional metrics
 			REAL sphericity = sigmaEst.CalculateSphericity(pStruct);
 			REAL volume = sigmaEst.ApproximateVolume(pStruct);
-			TRACE("  Sphericity: %.3f, Volume: %.1f cc\n",
+			RTM_TRACE("  Sphericity: %.3f, Volume: %.1f cc\n",
 				sphericity, volume);
 		}
 	}
 
-	TRACE("\n==========================================\n");
+	RTM_TRACE("\n==========================================\n");
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -342,7 +338,7 @@ void Example_HybridSigmaStrategy(CPlan* pPlan, Prescription* pPresc)
 			hybridSigmas[i] = DEFAULT_LEVELSIGMA[i];
 		}
 
-		TRACE("Level %d: Hybrid sigma = %.3f\n", i, hybridSigmas[i]);
+		RTM_TRACE("Level %d: Hybrid sigma = %.3f\n", i, hybridSigmas[i]);
 	}
 
 	// Use hybridSigmas in prescription setup...

--- a/RtModel/SphereConvolve.cpp
+++ b/RtModel/SphereConvolve.cpp
@@ -124,7 +124,7 @@ void
 				// integer distances between the interaction and the dose depostion voxels
 				VolumeReal::IndexType indexKernel = index;
 				indexKernel -= m_pOffsetLUT->GetPixel(indexTrace);
-				ASSERT(GetTerma()->GetRequestedRegion().IsInside(indexKernel));
+				assert(GetTerma()->GetRequestedRegion().IsInside(indexKernel));
 
 				// compute physical path length increment (in cm)
 				REAL deltaPhysDist = m_pDistanceLUT->GetPixel(indexTrace);

--- a/RtModel/Structure.cpp
+++ b/RtModel/Structure.cpp
@@ -2,6 +2,8 @@
 // $Id: Structure.cpp 640 2009-06-13 05:06:50Z dglane001 $
 #include "stdafx.h"
 
+#include <vector>
+
 #include <itkImageRegionConstIterator.h>
 #include <itkImageRegionIterator.h>
 #include <itkResampleImageFilter.h>
@@ -183,7 +185,7 @@ typedef itk::PolygonSpatialObject<2> PolygonType;
 // Creates a region (bit mask) from a polygon
 ///////////////////////////////////////////////////////////////////////////////
 template<class VOXEL_TYPE>
-void CreateRegionForPolygonSpatialObject(const CArray<PolygonType *, PolygonType *>& arrPolygons,
+void CreateRegionForPolygonSpatialObject(const std::vector<PolygonType *>& arrPolygons,
 				  itk::Image<VOXEL_TYPE,3> *pRegion, int nSlice)
 {
 	CDC dc;
@@ -199,11 +201,11 @@ void CreateRegionForPolygonSpatialObject(const CArray<PolygonType *, PolygonType
 
 	itk::Point<REAL,3> vOrigin = pRegion->GetOrigin();
 	itk::Vector<REAL,3> vSpacing = pRegion->GetSpacing();
-	for (int nAtPoly = 0; nAtPoly < arrPolygons.GetSize(); nAtPoly++)
+	for (int nAtPoly = 0; nAtPoly < (int) arrPolygons.size(); nAtPoly++)
 	{
 		// static 
-			CArray<CPoint, CPoint&> arrPoints;
-		arrPoints.SetSize(arrPolygons[nAtPoly]->GetNumberOfPoints/*GetVertexCount*/());
+			std::vector<CPoint> arrPoints;
+		arrPoints.resize(arrPolygons[nAtPoly]->GetNumberOfPoints/*GetVertexCount*/());
 		for (int nAt = 0; nAt < arrPolygons[nAtPoly]->GetNumberOfPoints/*GetVertexCount*/(); nAt++)
 		{
 			itk::SpatialObjectPoint<2> vVert = *(arrPolygons[nAtPoly]->GetPoint/*GetVertexAt*/(nAt));
@@ -213,7 +215,7 @@ void CreateRegionForPolygonSpatialObject(const CArray<PolygonType *, PolygonType
 			arrPoints[nAt].x = (vVert.GetPositionInObjectSpace()[0] - vOrigin[0]) / vSpacing[0];
 			arrPoints[nAt].y = (vVert.GetPositionInObjectSpace()[1] - vOrigin[1]) / vSpacing[1];
 		}
-		dc.Polygon(arrPoints.GetData(), arrPolygons[nAtPoly]->GetNumberOfPoints/*GetVertexCount*/());
+		dc.Polygon(arrPoints.data(), arrPolygons[nAtPoly]->GetNumberOfPoints/*GetVertexCount*/());
 	}
 
 	// finished with DC
@@ -226,9 +228,9 @@ void CreateRegionForPolygonSpatialObject(const CArray<PolygonType *, PolygonType
 
 	// resize the buffer
 	// static 
-		CArray<BYTE, BYTE> arrBuffer;
-	arrBuffer.SetSize(pRegion->GetBufferedRegion().GetSize()[1] * bm.bmWidthBytes);
-	int nByteCount = bitmap.GetBitmapBits((DWORD) arrBuffer.GetSize(), arrBuffer.GetData());
+		std::vector<BYTE> arrBuffer;
+	arrBuffer.resize(pRegion->GetBufferedRegion().GetSize()[1] * bm.bmWidthBytes);
+	int nByteCount = bitmap.GetBitmapBits((DWORD) arrBuffer.size(), arrBuffer.data());
 
 	// now populate region
 	// DON'T CLEAR REGION HERE -- this is called multiple times
@@ -266,13 +268,13 @@ void
 	for (int nSlice = 0; nSlice < pRegion->GetBufferedRegion().GetSize()[2]; nSlice++)
 	{
 		REAL slicePos = pRegion->GetOrigin()[2] + pRegion->GetSpacing()[2] * nSlice;
-		CArray<PolygonType *, PolygonType *> arrContours;
+		std::vector<PolygonType *> arrContours;
 		for (int nAt = 0; nAt < GetContourCount(); nAt++)
 		{
 			REAL zPos = GetContourRefDist(nAt);
 			if (IsApproxEqual(zPos, slicePos, pRegion->GetSpacing()[2] / 2.0))
 			{
-				arrContours.Add(GetContour(nAt));
+				arrContours.push_back(GetContour(nAt));
 			}
 		}
 		CreateRegionForPolygonSpatialObject(arrContours, pRegion, nSlice);

--- a/RtModel/include/Histogram.h
+++ b/RtModel/include/Histogram.h
@@ -2,6 +2,8 @@
 // $Id: Histogram.h 603 2008-09-14 16:58:43Z dglane001 $
 #pragma once
 
+#include <vector>
+
 #include <VectorN.h>
 #include <ItkUtils.h>
 // #include <ModelObject.h>
@@ -152,13 +154,13 @@ protected:
 	// should be moved to CHistogramGradient class
 
 	// flags for recalc
-	mutable CArray<bool, bool> m_arr_bRecomputeBinVolume;	// per group
+	mutable std::vector< bool > m_arr_bRecomputeBinVolume;	// per group
 
 	//// flags for recalc
-	mutable CArray<bool, bool> m_arr_bRecompute_dVolumes_x_Region;
+	mutable std::vector< bool > m_arr_bRecompute_dVolumes_x_Region;
 
 	// flags for recalc
-	mutable CArray<bool, bool> m_arr_bRecompute_dBins;
+	mutable std::vector< bool > m_arr_bRecompute_dBins;
 
 };	// class CHistogram
 

--- a/RtModel/include/HistogramGradient.h
+++ b/RtModel/include/HistogramGradient.h
@@ -62,7 +62,7 @@ protected:
 
 	// array of partial derivative volumes
 	std::vector< VolumeReal::Pointer > m_arr_dVolumes;
-	CArray<int, int> m_arrVolumeGroups;
+	std::vector< int > m_arrVolumeGroups;
 
 	// array of partial derivative X region
 	std::vector< VolumeReal::Pointer > m_arr_dVolumes_x_Region;
@@ -71,10 +71,10 @@ protected:
 	//mutable CArray<bool, bool> m_arr_bRecompute_dVolumes_x_Region;
 
 	// partial derivative histogram bins
-	mutable CArray<CVectorN<>, CVectorN<>&> m_arr_dBins;
+	mutable std::vector< CVectorN<> > m_arr_dBins;
 
 	// partial derivative histogram bins
-	mutable CArray<CVectorN<>, CVectorN<>&> m_arr_dGBins;
+	mutable std::vector< CVectorN<> > m_arr_dGBins;
 
 	//// flags for recalc
 	//mutable CArray<bool, bool> m_arr_bRecompute_dBins;

--- a/RtModel/include/ItkUtils.h
+++ b/RtModel/include/ItkUtils.h
@@ -13,6 +13,8 @@
 #endif
 
 
+#include <cassert>
+
 #include <itkImageRegionIterator.h>
 #include <itkImageRegionIteratorWithIndex.h>
 
@@ -169,8 +171,12 @@ itk::Vector<REAL,DIM>
 }
 
 //////////////////////////////////////////////////////////////////////
-template<int DIM> inline 
-itk::Vector<REAL, DIM> 
+// only available to translation units that have already pulled in MFC
+//	(i.e. Brimstone, which passes CPoint from its mouse handlers) --
+//	RtModel itself must not require MFC to compile this header.
+#ifdef __AFXWIN_H__
+template<int DIM> inline
+itk::Vector<REAL, DIM>
 	MakeVector(const CPoint& pt)
 {
 	itk::Vector<REAL, DIM> v;
@@ -179,6 +185,7 @@ itk::Vector<REAL, DIM>
 	for (int nC = 2; nC < DIM; nC++) v[nC] = 0.0;
 	return v;
 }
+#endif	// __AFXWIN_H__
 
 //////////////////////////////////////////////////////////////////////
 template<int DIM> inline 
@@ -256,159 +263,6 @@ void
 		for (int nC = 0; nC < DIM; nC++)
 			mBasis(nR, nC) = mDir(nR, nC) * vSpacing[nC];
 }
-
-
-//////////////////////////////////////////////////////////////////////
-template<int DIM, class TYPE> inline
-CArchive& 
-	operator<<(CArchive &ar, const itk::Point<TYPE, DIM>& v)
-	// vector serialization
-{
-	// serialize the individual row vectors
-	for (int nC = 0; nC < DIM; nC++)
-	{
-		ar << v[nC];
-	}
-
-	// return the archive object
-	return ar;
-
-}	// operator<<
-
-//////////////////////////////////////////////////////////////////////
-template<int DIM, class TYPE> inline
-CArchive& 
-	operator>>(CArchive &ar, itk::Point<TYPE, DIM>& v)
-	// vector serialization
-{
-	// serialize the individual row vectors
-	for (int nC = 0; nC < DIM; nC++)
-	{
-		ar >> v[nC];
-	}
-
-	// return the archive object
-	return ar;
-
-}	// operator>>
-
-//////////////////////////////////////////////////////////////////////
-template<int DIM, class TYPE> inline
-CArchive& 
-	operator<<(CArchive &ar, const itk::Vector<TYPE, DIM>& v)
-	// vector serialization
-{
-	// serialize the individual row vectors
-	for (int nC = 0; nC < DIM; nC++)
-	{
-		ar << v[nC];
-	}
-
-	// return the archive object
-	return ar;
-
-}	// operator<<
-
-//////////////////////////////////////////////////////////////////////
-template<int DIM, class TYPE> inline
-CArchive& 
-	operator>>(CArchive &ar, itk::Vector<TYPE, DIM>& v)
-	// vector serialization
-{
-	// serialize the individual row vectors
-	for (int nC = 0; nC < DIM; nC++)
-	{
-		ar >> v[nC];
-	}
-
-	// return the archive object
-	return ar;
-
-}	// operator>>
-
-//////////////////////////////////////////////////////////////////////
-template<int DIM, class TYPE> inline
-CArchive& 
-	operator<<(CArchive &ar, const itk::Matrix<TYPE, DIM, DIM>& m)
-	// matrix serialization
-{
-	// serialize the individual row vectors
-	for (int nC = 0; nC < DIM; nC++)
-	{
-		for (int nR = 0; nR < DIM; nR++)
-		{
-			ar << m(nR, nC);
-		}
-	}
-
-	// return the archive object
-	return ar;
-
-}	// operator<<
-
-
-//////////////////////////////////////////////////////////////////////
-template<int DIM, class TYPE> inline
-CArchive& 
-	operator>>(CArchive &ar, itk::Matrix<TYPE, DIM, DIM>& m)
-	// matrix serialization
-{
-	// serialize the individual row vectors
-	for (int nC = 0; nC < DIM; nC++)
-	{
-		for (int nR = 0; nR < DIM; nR++)
-		{
-			ar >> m(nR, nC);
-		}
-	}
-
-	// return the archive object
-	return ar;
-
-}	// operator>>
-
-
-//////////////////////////////////////////////////////////////////////
-template<int DIM> inline
-CArchive& 
-	operator<<(CArchive &ar, const itk::ImageRegion<DIM>& region)
-	// region serialization
-{
-	// serialize the individual elements
-	for (int nC = 0; nC < DIM; nC++)
-	{
-		ar << region.GetIndex()[nC];
-		ar << region.GetSize()[nC];
-	}
-	
-	// return the archive object
-	return ar;
-
-}	// operator<<
-
-
-//////////////////////////////////////////////////////////////////////
-template<int DIM> inline
-CArchive& 
-	operator>>(CArchive &ar, itk::ImageRegion<DIM>& region)
-	// region serialization
-{
-	itk::ImageRegion<DIM>::IndexType index;
-	itk::ImageRegion<DIM>::SizeType size;
-	// serialize the individual elements
-	for (int nC = 0; nC < DIM; nC++)
-	{
-		ar >> index[nC];
-		ar >> size[nC];
-	}
-
-	region.SetIndex(index);
-	region.SetSize(size);
-
-	// return the archive object
-	return ar;
-
-}	// operator>>
 
 
 //////////////////////////////////////////////////////////////////////
@@ -782,7 +636,7 @@ int
 //				int nSlice = 0)
 //	// accumulates voxel values -- other volume must be conformant
 //{
-//	ASSERT(pSrcDst->GetBufferedRegion().GetSize() == pVolume->GetBufferedRegion().GetSize());
+//	assert(pSrcDst->GetBufferedRegion().GetSize() == pVolume->GetBufferedRegion().GetSize());
 //
 //	int nStrideZ = pSrcDst->GetBufferedRegion().GetSize()[0]
 //		* pSrcDst->GetBufferedRegion().GetSize()[1];
@@ -819,7 +673,7 @@ void Accumulate3D(const VolumeReal *pVolume,
 				VolumeReal *pAccum)
 	// accumulates voxel values -- other volume must be conformant
 {
-	ASSERT(pSrcDst->GetBufferedRegion().GetSize() == pVolume->GetBufferedRegion().GetSize());
+	assert(pSrcDst->GetBufferedRegion().GetSize() == pVolume->GetBufferedRegion().GetSize());
 
 	typedef itk::ImageRegionConstIterator< VolumeReal > ConstIteratorType;
 	typedef itk::ImageRegionIterator< VolumeReal > IteratorType;
@@ -1041,153 +895,3 @@ inline void Decimate(const itk::Image<VOXEL_TYPE,3> *pVol,
 }	// Decimate
 #endif
 
-//////////////////////////////////////////////////////////////////////
-template<class VOXEL_TYPE> INLINE
-void SerializeImage(CArchive& ar, itk::Image<VOXEL_TYPE,2> *pImage)
-{
-	if (ar.IsStoring())
-	{
-		// serialize geometry
-		ar << pImage->GetOrigin();
-		ar << pImage->GetSpacing();
-		ar << pImage->GetDirection();
-
-		// serialize region
-		ar << pImage->GetBufferedRegion();
-
-		// serialize buffer
-		UINT nBytes = pImage->GetPixelContainer()->Size() * sizeof(VOXEL_TYPE);
-		ar.Write(pImage->GetBufferPointer(), nBytes);
-	}
-	else
-	{
-		typedef itk::Image<VOXEL_TYPE,2> ImageType;
-
-		// serialize geometry
-
-		ImageType::PointType origin;
-		ar >> origin;
-		pImage->SetOrigin(origin);
-
-		ImageType::SpacingType spacing;
-		ar >> spacing;
-		pImage->SetSpacing(spacing);
-
-		ImageType::DirectionType direction;
-		ar >> direction;
-		pImage->SetDirection(direction);
-
-		// serialize region
-
-		ImageType::RegionType region;
-		ar >> region;
-		pImage->SetRegions(region);
-		pImage->Allocate();
-
-		// serialize buffer
-
-		UINT nBytes = pImage->GetPixelContainer()->Size() * sizeof(VOXEL_TYPE);
-		UINT nActBytes = ar.Read(pImage->GetBufferPointer(), nBytes);
-		ASSERT(nActBytes == nBytes);
-	}
-}
-
-//////////////////////////////////////////////////////////////////////
-template<class VOXEL_TYPE> INLINE
-void SerializeVolume(CArchive& ar, itk::Image<VOXEL_TYPE,3> *pVolume)
-{
-	if (ar.IsStoring())
-	{
-		itk::Matrix<REAL, 4, 4> mBasis;
-		CalcBasis<3>(pVolume, mBasis);
-		ar << mBasis;
-
-		itk::Size<3> sz = pVolume->GetBufferedRegion().GetSize();
-		ar << (int) sz[0]; 
-		ar << (int) sz[1]; 
-		ar << (int) sz[2]; 
-
-		UINT nBytes = sz[2] * sz[1] * sz[0] * sizeof(VOXEL_TYPE);
-		ar.Write(pVolume->GetBufferPointer(), nBytes);
-	}
-	else
-	{
-		itk::Matrix<REAL, 4, 4> mBasis;
-		ar >> mBasis;
-
-		itk::Image<VOXEL_TYPE,3>::PointType origin;
-		origin[0] = mBasis(0, 3);
-		origin[1] = mBasis(1, 3);
-		origin[2] = mBasis(2, 3);
-		pVolume->SetOrigin(origin);
-
-		// VolumeType::DirectionType 
-		itk::Matrix<double, 3, 3> mDir;
-		itk::Image<VOXEL_TYPE,3>::SpacingType spacing;
-		for (int nCol = 0; nCol < 3; nCol++)
-		{
-			itk::Vector<REAL> vDir;
-			vDir[0] = mBasis(0,nCol);
-			vDir[1] = mBasis(1,nCol);
-			vDir[2] = mBasis(2,nCol);
-			spacing[nCol] = vDir.GetNorm();
-
-			vDir.Normalize();
-			mDir(0,nCol) = vDir[0];
-			mDir(1,nCol) = vDir[1];
-			mDir(2,nCol) = vDir[2];
-		}
-		pVolume->SetSpacing(spacing);
-		pVolume->SetDirection(mDir);
-
-		// get size as 3 ints
-		itk::Vector<int, 3> m_vSize;
-		ar >> m_vSize[0];
-		ar >> m_vSize[1];
-		ar >> m_vSize[2];
-
-		// set size as an ItkSize
-		pVolume->SetRegions( MakeSize(m_vSize[0], m_vSize[1], m_vSize[2]) );
-		pVolume->Allocate();
-
-		UINT nBytes = m_vSize[2] * m_vSize[1] * m_vSize[0] * sizeof(VOXEL_TYPE);
-		UINT nActBytes = ar.Read(pVolume->GetBufferPointer(), nBytes);
-		ASSERT(nActBytes == nBytes);
-	}
-}
-
-//////////////////////////////////////////////////////////////////////
-template<int DIM> INLINE
-void SerializePolyLine(CArchive& ar,
-					   itk::PolyLineParametricPath<DIM> *pPoly)
-{
-	typedef itk::PolyLineParametricPath<DIM>::VertexType VertexType;
-
-	CMatrixNxM<VertexType::CoordRepType> m_mVertex;
-
-	if (ar.IsStoring())
-	{
-		const itk::PolyLineParametricPath<DIM>::VertexListType *pVertList = pPoly->GetVertexList();
-		m_mVertex.Reshape(pVertList->size(), DIM, FALSE);
-		for (int nVert = 0; nVert < pVertList->size(); nVert++)
-		{
-			for (int nCoord = 0; nCoord < DIM; nCoord++)
-				m_mVertex[nVert][nCoord] = pVertList->at(nVert)[nCoord];
-		}
-	}
-
-	SerializeValue(ar, m_mVertex);
-
-	if (ar.IsLoading())
-	{
-		// clears any existing vertices
-		pPoly->Initialize();
-		for (int nVert = 0; nVert < m_mVertex.GetCols(); nVert++)
-		{
-			VertexType vertex;
-			for (int nCoord = 0; nCoord < DIM; nCoord++)
-				vertex[nCoord] = m_mVertex[nVert][nCoord];
-			pPoly->AddVertex(vertex);
-		}
-	}
-}

--- a/RtModel/include/KLDivTerm.h
+++ b/RtModel/include/KLDivTerm.h
@@ -48,7 +48,7 @@ private:
 	const CVectorN<>& GetTargetGBins() const;
 public:
 	// evaluates the term
-	virtual REAL Eval(CVectorN<> *pvGrad, const CArray<BOOL, BOOL>& arrInclude);
+	virtual REAL Eval(CVectorN<> *pvGrad, const std::vector<BOOL>& arrInclude);
 
 	// over-ride to create subcopy
 	virtual VOITerm *Clone();

--- a/RtModel/include/MathUtil.h
+++ b/RtModel/include/MathUtil.h
@@ -4,8 +4,13 @@
 #define MATHUTIL_H
 
 // standard math libraries
+#include <cassert>
+#include <cctype>
+#include <cstdlib>
 #include <math.h>
 #include <float.h>
+
+#include <string>
 
 #include <complex>
 using namespace std;
@@ -44,7 +49,7 @@ const REAL DEFAULT_EPSILON = (REAL) 1e-5;
 //////////////////////////////////////////////////////////////////////
 #ifdef USE_IPP
 #ifdef _DEBUG
-#define CK_IPP(x) { IppStatus stat = (x); ASSERT(stat == ippStsOk); }
+#define CK_IPP(x) { IppStatus stat = (x); assert(stat == ippStsOk); }
 #else
 #define CK_IPP(x) (x);
 #endif
@@ -165,8 +170,8 @@ inline REAL AngleFromSinCos(REAL sin_angle, REAL cos_angle)
 
 	// now check
 #ifdef _DEBUG_ACCURACY
-	ASSERT(fabs(sin(angle) - sin_angle) < 1e-6);
-	ASSERT(fabs(cos(angle) - cos_angle) < 1e-6);
+	assert(fabs(sin(angle) - sin_angle) < 1e-6);
+	assert(fabs(cos(angle) - cos_angle) < 1e-6);
 #endif
 
 	return angle;
@@ -237,10 +242,10 @@ inline TYPE InvSigmoid(TYPE y, TYPE scale /* = 1.0 */)
 	// compute value
 	TYPE value = (TYPE) (-log(1.0 / y - 1.0) 
 		/ scale);
-	ASSERT(_finite(value));
+	assert(_finite(value));
 
 	// test result
-	ASSERT(IsApproxEqual(Sigmoid(value, scale), y));
+	assert(IsApproxEqual(Sigmoid(value, scale), y));
 
 	// return
 	return value;
@@ -258,33 +263,45 @@ inline TYPE InvSigmoid(TYPE y, TYPE scale /* = 1.0 */)
 
 
 // only use if we have included necessary AFX calls
-#ifdef __AFXWIN_H__
 //////////////////////////////////////////////////////////////////////
-// GetProfileReal
+// settings lookup
 //
-// function for real-valued registry values
+// A section + name pair maps to the environment variable
+// BRIMSTONE_<SECTION>_<NAME>, upper-cased -- so ("Prescription",
+// "LevelSigma0") is read from BRIMSTONE_PRESCRIPTION_LEVELSIGMA0.
+// If the variable is unset, the caller's default stands.  This
+// replaces the former AfxGetApp()->GetProfileString registry lookup,
+// and matches the BRIMSTONE_* convention already used elsewhere.
+//////////////////////////////////////////////////////////////////////
+inline std::string MakeSettingKey(const char *pszSection, const char *pszName)
+{
+	std::string strKey("BRIMSTONE_");
+	strKey += pszSection;
+	strKey += "_";
+	strKey += pszName;
+
+	for (size_t nAt = 0; nAt < strKey.size(); nAt++)
+		strKey[nAt] = (char) toupper((unsigned char) strKey[nAt]);
+
+	return strKey;
+
+}	// MakeSettingKey
+
 //////////////////////////////////////////////////////////////////////
 inline REAL GetProfileReal(const char *pszSection, const char *pszName, double default_value)
 {
-	USES_CONVERSION;
-
-	CString strValue;
-	strValue.Format(_T("%lf"), default_value);
-	
-	// get profile string, or default value
-	strValue = ::AfxGetApp()->GetProfileString(A2T(pszSection), A2T(pszName), strValue);
-
-	// turn to REAL
-	REAL value;
-	_stscanf_s(strValue.GetBuffer(), _T(REAL_FMT), &value);
-
-	// make sure parameter is written, so it can be modified through RegEdit
-	::AfxGetApp()->WriteProfileString(A2T(pszSection), A2T(pszName), strValue);
-
-	return value;
+	const char *pEnv = getenv(MakeSettingKey(pszSection, pszName).c_str());
+	return (pEnv != NULL) ? (REAL) atof(pEnv) : (REAL) default_value;
 
 }	// GetProfileReal
-#endif
+
+//////////////////////////////////////////////////////////////////////
+inline int GetProfileInt(const char *pszSection, const char *pszName, int default_value)
+{
+	const char *pEnv = getenv(MakeSettingKey(pszSection, pszName).c_str());
+	return (pEnv != NULL) ? atoi(pEnv) : default_value;
+
+}	// GetProfileInt
 
 //////////////////////////////////////////////////////////////////////
 // functions for complex values
@@ -310,6 +327,6 @@ inline REAL conjg(const REAL& c)
 }
 
 
-#define CK_BOOL(x) if (!(x)) TRACE("CK_BOOL failed\n");
+#define CK_BOOL(x) if (!(x)) RTM_TRACE("CK_BOOL failed\n");
 
 #endif // !defined(MATHUTIL_H)

--- a/RtModel/include/MatrixNxM.h
+++ b/RtModel/include/MatrixNxM.h
@@ -152,8 +152,8 @@ CMatrixNxM<TYPE>&
 	// assignment operator
 {
 	// checks the dimensions
-	ASSERT(GetCols() == fromMatrix.GetCols());
-	ASSERT(GetRows() == fromMatrix.GetRows());
+	assert(GetCols() == fromMatrix.GetCols());
+	assert(GetRows() == fromMatrix.GetRows());
 
 	if (GetCols() > 0)
 	{
@@ -259,7 +259,7 @@ CVectorN<TYPE>&
 	// retrieves a reference to a column vector
 {
 	// bounds check on the index
-	ASSERT(nAtCol >= 0 && nAtCol < GetCols());
+	assert(nAtCol >= 0 && nAtCol < GetCols());
 
 	// return a reference to the column vector
 	return m_pColumns[nAtCol];
@@ -274,7 +274,7 @@ const CVectorN<TYPE>&
 	// retrieves a reference to a column vector
 {
 	// bounds check on the index
-	ASSERT(nAtCol >= 0 && nAtCol < GetCols());
+	assert(nAtCol >= 0 && nAtCol < GetCols());
 
 	// return a reference to the column vector
 	return m_pColumns[nAtCol];
@@ -338,7 +338,7 @@ bool
 	CMatrixNxM<TYPE>::IsApproxEqual(const CMatrixNxM& m, TYPE epsilon) const
 	// tests for approximate equality using the EPS 
 {
-	ASSERT(GetCols() == m.GetCols());
+	assert(GetCols() == m.GetCols());
 
 	for (int nAtCol = 0; nAtCol < GetCols(); nAtCol++)
 	{
@@ -359,8 +359,8 @@ CMatrixNxM<TYPE>&
 	CMatrixNxM<TYPE>::operator+=(const CMatrixNxM<TYPE>& mRight)
 	// in-place matrix addition; returns a reference to this
 {
-	ASSERT(GetCols() == mRight.GetCols());
-	ASSERT(GetRows() == mRight.GetRows());
+	assert(GetCols() == mRight.GetCols());
+	assert(GetRows() == mRight.GetRows());
 
 	SumValues(&(*this)[0][0], &mRight[0][0], GetCols() * GetRows());
 
@@ -376,8 +376,8 @@ CMatrixNxM<TYPE>&
 	CMatrixNxM<TYPE>::operator-=(const CMatrixNxM<TYPE>& mRight)
 	// in-place matrix subtraction; returns a reference to 	this
 {
-	ASSERT(GetCols() == mRight.GetCols());
-	ASSERT(GetRows() == mRight.GetRows());
+	assert(GetCols() == mRight.GetCols());
+	assert(GetRows() == mRight.GetRows());
 
 	DiffValues(&(*this)[0][0], &mRight[0][0], GetCols() * GetRows());
 
@@ -629,46 +629,5 @@ CMatrixNxM<TYPE> operator*(const CMatrixNxM<TYPE>& mLeft,
 
 }	// operator*(const CMatrixNxM<TYPE>&, const CMatrixNxM<TYPE>&)
 
-// operator overloads for serialization
-#ifdef __AFX_H__
-
-//////////////////////////////////////////////////////////////////////
-template<class TYPE>
-CArchive& 
-	operator<<(CArchive &ar, CMatrixNxM<TYPE> m)
-	// matrix serialization in
-{
-	// serialize the dimension
-	ar << m.GetCols();
-	ar << m.GetRows();
-
-	// serialize the individual elements
-	ar.Write((TYPE *) m, m.GetCols() * m.GetRows() * sizeof(TYPE));
-
-	// return the archive object
-	return ar;
-
-}	// operator<<(CArchive &ar, CMatrixNxM<TYPE> m)
-
-//////////////////////////////////////////////////////////////////////
-template<class TYPE>
-CArchive& 
-	operator>>(CArchive &ar, CMatrixNxM<TYPE>& m)
-	// matrix serialization out
-{
-	// serialize the dimension
-	int nCols, nRows;
-	ar >> nCols >> nRows;
-	m.Reshape(nCols, nRows);
-
-	// serialize the individual elements
-	ar.Read((TYPE *) m, nCols * nRows * sizeof(TYPE));
-
-	// return the archive object
-	return ar;
-
-}	// operator>>(CArchive &ar, CMatrixNxM<TYPE>& m)
-
-#endif	// __AFX_H__
 
 #endif	// MATRIXNXM_H

--- a/RtModel/include/Plan.h
+++ b/RtModel/include/Plan.h
@@ -8,6 +8,9 @@
 #endif // _MSC_VER > 1000
 
 // series upon which plan is based
+#include <map>
+#include <string>
+
 #include <Series.h>
 
 // beams belonging to the plan
@@ -94,7 +97,7 @@ public:
 
 private:
 	/** the histograms */
-	CTypedPtrMap<CMapStringToOb, CString, CHistogram*> m_mapHistograms;
+	std::map<std::string, CHistogram *> m_mapHistograms;
 
 };	// class Plan
 

--- a/RtModel/include/Prescription.h
+++ b/RtModel/include/Prescription.h
@@ -2,6 +2,9 @@
 // $Id: Prescription.h 640 2009-06-13 05:06:50Z dglane001 $
 // #include <ModelObject.h>
 
+#include <map>
+#include <vector>
+
 #include <ObjectiveFunction.h>
 // #include <Optimizer.h>
 
@@ -62,7 +65,7 @@ public:
 	// initial step in objective function -- forming sum and histogram
 	void CalcSumSigmoid(CHistogramWithGradient *pHisto, const CVectorN<>& vInput,
 		const CVectorN<>& vInputTrans,
-		const CArray<BOOL, BOOL>& arrInclude) const;
+		const std::vector<BOOL>& arrInclude) const;
 
 	// transform function from linear to other parameter space
 	virtual void Transform(CVectorN<> *pvInOut) const;
@@ -117,15 +120,14 @@ public:
 	mutable CVectorN<> m_ActualAV;
 
 	// stores the VOITs
-	/// TODO: change this to std::map
-	CTypedPtrMap<CMapPtrToPtr, Structure*, VOITerm*> m_mapVOITs;
+	typedef std::map<Structure *, VOITerm *> VOITMapType;
+	VOITMapType m_mapVOITs;
 
 	// helpers for Eval_TotalEntropy
 	mutable CVectorN<> m_vPartGrad;
 
 	// array of flags for element inclusion
-	/// TODO: change this to std::vector
-	CArray<BOOL, BOOL> m_arrIncludeElement;
+	std::vector<BOOL> m_arrIncludeElement;
 
 	// last-evaluated split of the objective F = KL - w*entropy (for reporting)
 	mutable REAL m_dLastKL;

--- a/RtModel/include/VOITerm.h
+++ b/RtModel/include/VOITerm.h
@@ -1,5 +1,7 @@
 // Copyright (C) 2nd Messenger Systems - U. S. Patent 7,369,645
 // $Id: VOITerm.h 640 2009-06-13 05:06:50Z dglane001 $
+#include <vector>
+
 #include <HistogramGradient.h>
 
 #pragma once
@@ -33,8 +35,7 @@ public:
 	DECLARE_ATTRIBUTE(Weight, REAL);
 
 	// over-ride for real terms
-	/// TODO: change CArray to std::vector
-	virtual REAL Eval(CVectorN<> *pvGrad, const CArray<BOOL, BOOL>& arrInclude) = 0;
+	virtual REAL Eval(CVectorN<> *pvGrad, const std::vector<BOOL>& arrInclude) = 0;
 
 	// helper to create pyramid - constructs a copy, except with nScale + 1
 	virtual VOITerm *Clone() = 0;

--- a/RtModel/include/VectorN.h
+++ b/RtModel/include/VectorN.h
@@ -7,10 +7,17 @@
 #include <ipp.h>
 #endif
 
+#include <cstdio>
+#include <string>
+
 #include <vnl/vnl_vector_ref.h>
 #include <MathUtil.h>
 
 #include <VectorOps.h>
+
+// RTM_TRACE (used by Trace() below) lives here; include so this header is
+// self-contained regardless of the including project's include order.
+#include <utilmacros.h>
 
 //////////////////////////////////////////////////////////////////////
 // class CVectorN<TYPE>
@@ -105,9 +112,6 @@ public:
 	int CopyElements(const CVectorN<TYPE>& v, int nStart, int nLength, 
 		int nDest = 0);
 
-	// create a printable string representation
-	CString ToString();
-
 };	// class CVectorN<TYPE>
 
 
@@ -185,7 +189,7 @@ CVectorN<TYPE>&
 	// assignment operator
 {
 	// check the dimensionality of the vector
-	ASSERT(GetDim() == vFrom.GetDim());
+	assert(GetDim() == vFrom.GetDim());
 
 	if (GetDim() > 0)
 	{
@@ -212,7 +216,7 @@ TYPE&
 	// returns a reference to the specified element.
 {
 	// check dimensions
-	ASSERT(nAtRow >= 0 && nAtRow < GetDim());
+	assert(nAtRow >= 0 && nAtRow < GetDim());
 
 	return m_pElements[nAtRow];
 
@@ -226,7 +230,7 @@ const TYPE&
 	// returns a const reference to the specified element.
 {
 	// check dimensions
-	ASSERT(nAtRow >= 0 && nAtRow < GetDim());
+	assert(nAtRow >= 0 && nAtRow < GetDim());
 
 	return m_pElements[nAtRow];
 
@@ -588,109 +592,55 @@ void
 }	// CalcBinomialCoeff
 
 
-inline void Trace(LPTSTR label, double value)
+inline void Trace(const char *label, double value)
 {
-	CString str;
-	str.Format(_T("%s =\t% .4lf\n"), label, value);
-	OutputDebugString(str.GetBuffer());
-}	
+	RTM_TRACE("%s =\t% .4lf\n", label, value);
+}
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE>
-void 
-	TraceVector(LPTSTR label, const CVectorN<TYPE>& vTrace)
+void
+	TraceVector(const char *label, const CVectorN<TYPE>& vTrace)
 	// helper function to output a vector for debugging
 {
-	CString str;
-	str.Format(_T("%s[%d] =\t<"), label, vTrace.GetDim());
+	char szChunk[64];
+	snprintf(szChunk, sizeof(szChunk), "%s[%d] =\t<", label, vTrace.GetDim());
+
+	std::string str(szChunk);
 #ifdef TRACE_VECTOR_NUMERIC
 	for (int nAt = 0; nAt < vTrace.GetDim(); nAt++)
 	{
-		str.AppendFormat(_T("% .4lf|"), vTrace[nAt]);
+		snprintf(szChunk, sizeof(szChunk), "% .4lf|", (double) vTrace[nAt]);
+		str += szChunk;
 	}
 #else
 	double maxElement = -1e-20;
 	for (int nAt = 0; nAt < vTrace.GetDim(); nAt++)
 		maxElement = __max(maxElement, vTrace[nAt]);
 
-	str.AppendFormat(_T("% .4lf"), maxElement);
+	snprintf(szChunk, sizeof(szChunk), "% .4lf", maxElement);
+	str += szChunk;
 
 	for (int nAt = 0; nAt < vTrace.GetDim(); nAt++)
 	{
 		if (vTrace[nAt] < maxElement * 0.1)
-			str.AppendFormat(_T(" "));
+			str += " ";
 		else if (vTrace[nAt] < maxElement * 0.25)
-			str.AppendFormat(_T("."));
+			str += ".";
 		else if (vTrace[nAt] < maxElement * 0.85)
-			str.AppendFormat(_T(":"));
+			str += ":";
 		else
-			str.AppendFormat(_T("|"));
+			str += "|";
 	}
 #endif
-	str.AppendFormat(_T(">\n"));
-	OutputDebugString(str.GetBuffer());
+	str += ">\n";
+	RTM_TRACE("%s", str.c_str());
 
 }	// TraceVector
 
 
-//////////////////////////////////////////////////////////////////////
-// TRACE_VECTOR
-//
-// macro to trace matrix -- only compiles in debug version
-//////////////////////////////////////////////////////////////////////
-#ifdef _DEBUG
-#define TRACE_VECTOR(strMessage, v) \
-	TRACE(strMessage);				\
-	TraceVector(v);					\
-	TRACE("\n");
-#else
-#define TRACE_VECTOR(strMessage, v)
-#endif
 
 
 
-#ifdef __AFX_H__
-
-//////////////////////////////////////////////////////////////////////
-template<class TYPE>
-CArchive& 
-	operator<<(CArchive &ar, CVectorN<TYPE> v)
-	// CArchive serialization of a vector
-{
-	// store the dimension first
-	ar << v.GetDim();
-
-	// store the elements
-	for (int nAt = 0; nAt < v.GetDim(); nAt++)
-	{
-		ar << v[nAt];
-	}
-
-	return ar;
-
-}	// operator<<(CArchive &ar, CVectorN<TYPE> v)
-
-//////////////////////////////////////////////////////////////////////
-template<class TYPE>
-CArchive& 
-	operator>>(CArchive &ar, CVectorN<TYPE>& v)
-	// CArchive de-serialization of a vector
-{
-	// retrieve the dimension first
-	int nDim;
-	ar >> nDim;
-	v.SetDim(nDim);
-
-	// retrieve the elements
-	for (int nAt = 0; nAt < v.GetDim(); nAt++)
-	{
-		ar >> v[nAt];
-	}
-
-	return ar;
-
-}	// operator>>(CArchive &ar, CVectorN<TYPE>& v)
-
-#endif	// __AFX_H__
 
 #endif	// !defined(VECTORN_H)

--- a/RtModel/include/utilmacros.h
+++ b/RtModel/include/utilmacros.h
@@ -9,6 +9,33 @@
 #define UTILMACROS_H
 
 //////////////////////////////////////////////////////////////////////
+// Debug macros
+//
+// MFC-free replacements for ASSERT / TRACE.  Call sites use assert()
+// directly; RTM_TRACE mirrors the old TRACE -- printf-style, and
+// compiled out entirely in release builds.
+//////////////////////////////////////////////////////////////////////
+
+#include <cassert>
+#include <cstdio>
+
+#ifndef _DEBUG
+#define RTM_TRACE(...) ((void) 0)
+#elif defined(_WIN32)
+// routed to the debugger output window, as TRACE was
+#define RTM_TRACE(...)									\
+{														\
+	char _rtmTraceBuf[1024];							\
+	_snprintf_s(_rtmTraceBuf, sizeof(_rtmTraceBuf),		\
+		_TRUNCATE, __VA_ARGS__);						\
+	::OutputDebugStringA(_rtmTraceBuf);					\
+}
+#else
+#define RTM_TRACE(...) \
+	std::fprintf(stderr, __VA_ARGS__)
+#endif
+
+//////////////////////////////////////////////////////////////////////
 // Macros for attributes
 //////////////////////////////////////////////////////////////////////
 
@@ -116,37 +143,6 @@ public:										\
 
 #define EndNamespace(NAME) }
 
-//////////////////////////////////////////////////////////////////////
-// Macros for serialization
-//////////////////////////////////////////////////////////////////////
-
-#define SERIALIZE_VALUE(ar, value) \
-	if (ar.IsLoading())				\
-	{								\
-		ar >> value;				\
-	}								\
-	else							\
-	{								\
-		ar << value;				\
-	}
-
-#define SerializeValue(ar, value) \
-	if (ar.IsLoading())				\
-	{								\
-		ar >> value;				\
-	}								\
-	else							\
-	{								\
-		ar << value;				\
-	}
-
-#define SERIALIZE_ARRAY(ar, array) \
-	if (ar.IsLoading())				\
-	{								\
-		array.RemoveAll();			\
-	}								\
-	array.Serialize(ar);
-
 
 
 #define CHECK_HRESULT(call) \
@@ -164,7 +160,7 @@ public:										\
 	HRESULT hr = (Cmd); \
 	if (FAILED(hr))		\
 	{					\
-		TRACE("COM Command Failed -- Error %x\n", hr); \
+		RTM_TRACE("COM Command Failed -- Error %x\n", hr); \
 		return hr;		\
 	}					\
 }
@@ -176,25 +172,6 @@ if (!(expr))				\
 }
 
 
-//////////////////////////////////////////////////////////////////////
-// Macros for trace dumps
-//////////////////////////////////////////////////////////////////////
-
-#define CREATE_TAB(LENGTH) \
-	CString TAB; \
-	while (TAB.GetLength() < LENGTH * 2) \
-		TAB += "\t\t"
-
-#define DC_TAB(DUMP_CONTEXT) \
-	DUMP_CONTEXT << TAB
-
-#define PUSH_DUMP_DEPTH(DUMP_CONTEXT) \
-	int OLD_DUMP_DEPTH = DUMP_CONTEXT.GetDepth(); \
-	DUMP_CONTEXT.SetDepth(OLD_DUMP_DEPTH + 1)
-
-#define POP_DUMP_DEPTH(DUMP_CONTEXT) \
-	DUMP_CONTEXT.SetDepth(OLD_DUMP_DEPTH)
-
 // prevent re-definition of these
 #ifndef LOG_MACROS_DEFINED
 #define LOG_MACROS_DEFINED
@@ -204,34 +181,19 @@ if (!(expr))				\
 #define LOG_HRESULT(call) \
 {							\
 	HRESULT hr = call;		\
-	ATLASSERT(SUCCEEDED(hr));	\
+	assert(SUCCEEDED(hr));	\
 }
 
 // log file utilities
 #define BeginLogSection(section_name) { \
-	LPCTSTR __section_name = section_name; \
-	CString __formatMessage; \
-	__formatMessage.Format(_T("<log_section name=\"%s\">"), __section_name); \
-	OutputDebugString(__formatMessage.GetBuffer());
+	RTM_TRACE("<log_section name=\"%s\">", section_name);
 
 #define EndLogSection() \
-	OutputDebugString(_T("</log_section>\n")); }
+	RTM_TRACE("</log_section>\n"); }
 
-#define Log OutputDebugString
+#define Log(message) RTM_TRACE("%s", message)
 
 #endif
-
-// profile flag to control behavior
-#define PROFILE_FLAG(Section, Key) \
-	static BOOL bInit = FALSE;		\
-	static BOOL bShow = FALSE;		\
-	if (!bInit)						\
-	{								\
-		bShow =						\
-			(BOOL) ::AfxGetApp()->GetProfileInt(Section, Key, 0);	\
-		bInit = TRUE;				\
-	}								\
-	if (bShow)				
 
 
 #endif

--- a/RtModel/stdafx.h
+++ b/RtModel/stdafx.h
@@ -8,7 +8,6 @@
 #endif // _MSC_VER > 1000
 
 #define WIN32_LEAN_AND_MEAN		// Exclude rarely-used stuff from Windows headers
-#define _ATL_CSTRING_EXPLICIT_CONSTRUCTORS	// some CString constructors will be explicit
 
 #ifndef VC_EXTRALEAN
 #define VC_EXTRALEAN		// Exclude rarely-used stuff from Windows headers


### PR DESCRIPTION
Modernize codebase by replacing MFC/ATL types (CString, CArray, CMap) with std::string, std::vector, and std::map. Replace MFC logging, assertions, and registry/profile access with portable C++ alternatives using assert(), RTM_TRACE, and environment variables. Remove MFC serialization and macros. Update Visual Studio projects to add ARM64 configs, update toolset, add vcpkg paths, and remove IPP for ARM64. Improves portability, maintainability, and cross-platform support.